### PR TITLE
Add closures support for compilation speed

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,14 +22,14 @@ CUDAExt = "CUDA"
 oneAPIExt = "oneAPI"
 
 [compat]
-julia = "1.10"
 AMDGPU = "1"
 CUDA = "5"
 DataStructures = "0.18"
 NumaAllocators = "0.2"
-oneAPI = "1"
 RuntimeGeneratedFunctions = "0.5"
 StaticArrays = "1"
+julia = "1.10"
+oneAPI = "1"
 
 [extras]
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"

--- a/ext/devices/cuda/function.jl
+++ b/ext/devices/cuda/function.jl
@@ -6,12 +6,15 @@ function ComputableDAGs.kernel(
 
     init_caches = Expr(:block, tape.initCachesCode...)
     assign_inputs = Expr(:block, ComputableDAGs.expr_from_fc.(tape.inputAssignCode)...)
+    # TODO: use gen_function_body here
     code = Expr(:block, ComputableDAGs.expr_from_fc.(tape.computeCode)...)
 
     function_id = ComputableDAGs.to_var_name(UUIDs.uuid1(ComputableDAGs.rng[1]))
     res_sym = eval(
-        ComputableDAGs.gen_access_expr(
-            ComputableDAGs.entry_device(tape.machine), tape.outputSymbol
+        ComputableDAGs._gen_access_expr(
+            ComputableDAGs.entry_device(tape.machine),
+            ComputableDAGs.entry_device(tape.machine).cacheStrategy,
+            tape.outputSymbol,
         ),
     )
     expr = Meta.parse(

--- a/ext/devices/cuda/function.jl
+++ b/ext/devices/cuda/function.jl
@@ -7,7 +7,7 @@ function ComputableDAGs.kernel(
     init_caches = Expr(:block, tape.initCachesCode...)
     assign_inputs = Expr(:block, ComputableDAGs.expr_from_fc.(tape.inputAssignCode)...)
     # TODO: use gen_function_body here
-    code = Expr(:block, ComputableDAGs.expr_from_fc.(tape.computeCode)...)
+    code = Expr(:block, ComputableDAGs.expr_from_fc.(tape.schedule)...)
 
     function_id = ComputableDAGs.to_var_name(UUIDs.uuid1(ComputableDAGs.rng[1]))
     res_sym = eval(

--- a/ext/devices/rocm/function.jl
+++ b/ext/devices/rocm/function.jl
@@ -6,18 +6,22 @@ function ComputableDAGs.kernel(
 
     init_caches = Expr(:block, tape.initCachesCode...)
     assign_inputs = Expr(:block, ComputableDAGs.expr_from_fc.(tape.inputAssignCode)...)
+
+    # TODO use gen_function_body here
     code = Expr(:block, ComputableDAGs.expr_from_fc.(tape.computeCode)...)
 
     function_id = ComputableDAGs.to_var_name(UUIDs.uuid1(ComputableDAGs.rng[1]))
     res_sym = eval(
-        ComputableDAGs.gen_access_expr(
-            ComputableDAGs.entry_device(tape.machine), tape.outputSymbol
+        ComputableDAGs._gen_access_expr(
+            ComputableDAGs.entry_device(tape.machine),
+            ComputableDAGs.entry_device(tape.machine).cacheStrategy,
+            tape.outputSymbol,
         ),
     )
     expr = Meta.parse(
         "function compute_$(function_id)(input_vector, output_vector, n::Int64)
             id = (workgroupIdx().x - 1) * workgroupDim().x + workgroupIdx().x
-            if (id > n)  
+            if (id > n)
                 return
             end
             @inline data_input = input_vector[id]

--- a/ext/devices/rocm/function.jl
+++ b/ext/devices/rocm/function.jl
@@ -8,7 +8,7 @@ function ComputableDAGs.kernel(
     assign_inputs = Expr(:block, ComputableDAGs.expr_from_fc.(tape.inputAssignCode)...)
 
     # TODO use gen_function_body here
-    code = Expr(:block, ComputableDAGs.expr_from_fc.(tape.computeCode)...)
+    code = Expr(:block, ComputableDAGs.expr_from_fc.(tape.schedule)...)
 
     function_id = ComputableDAGs.to_var_name(UUIDs.uuid1(ComputableDAGs.rng[1]))
     res_sym = eval(

--- a/src/ComputableDAGs.jl
+++ b/src/ComputableDAGs.jl
@@ -130,6 +130,7 @@ include("scheduler/interface.jl")
 include("scheduler/greedy.jl")
 
 include("code_gen/type.jl")
+include("code_gen/utils.jl")
 include("code_gen/tape_machine.jl")
 include("code_gen/function.jl")
 

--- a/src/code_gen/function.jl
+++ b/src/code_gen/function.jl
@@ -17,10 +17,10 @@ in your top level.
 
 ## Keyword Arguments
 
-`closures_size` (default=500): The size of closures to use in the main generated code. This specifies the size of code blocks across which the compiler cannot optimize. For sufficiently large functions, a larger value means longer compile times but potentially faster execution time.
+`closures_size` (default=0 (off)): The size of closures to use in the main generated code. This specifies the size of code blocks across which the compiler cannot optimize. For sufficiently large functions, a larger value means longer compile times but potentially faster execution time.
 """
 function get_compute_function(
-    graph::DAG, instance, machine::Machine, context_module::Module; closures_size=500
+    graph::DAG, instance, machine::Machine, context_module::Module; closures_size=0
 )
     tape = gen_tape(graph, instance, machine, context_module)
 

--- a/src/code_gen/function.jl
+++ b/src/code_gen/function.jl
@@ -26,7 +26,7 @@ function get_compute_function(
 
     initCaches = Expr(:block, tape.initCachesCode...)
     assignInputs = Expr(:block, expr_from_fc.(tape.inputAssignCode)...)
-    code = gen_function_body(tape.computeCode; closures_size=closures_size)
+    code = gen_function_body(tape; closures_size=closures_size)
 
     functionId = to_var_name(UUIDs.uuid1(rng[1]))
     resSym = eval(

--- a/src/code_gen/function.jl
+++ b/src/code_gen/function.jl
@@ -14,18 +14,28 @@ using RuntimeGeneratedFunctions
 RuntimeGeneratedFunctions.init(@__MODULE__)
 ```
 in your top level.
+
+## Keyword Arguments
+
+`closures_size` (default=500): The size of closures to use in the main generated code. This specifies the size of code blocks across which the compiler cannot optimize. For sufficiently large functions, a larger value means longer compile times but potentially faster execution time.
 """
 function get_compute_function(
-    graph::DAG, instance, machine::Machine, context_module::Module
+    graph::DAG, instance, machine::Machine, context_module::Module; closures_size=500
 )
     tape = gen_tape(graph, instance, machine, context_module)
 
     initCaches = Expr(:block, tape.initCachesCode...)
     assignInputs = Expr(:block, expr_from_fc.(tape.inputAssignCode)...)
-    code = Expr(:block, expr_from_fc.(tape.computeCode)...)
+    code = gen_function_body(tape.computeCode; closures_size=closures_size)
 
     functionId = to_var_name(UUIDs.uuid1(rng[1]))
-    resSym = eval(gen_access_expr(entry_device(tape.machine), tape.outputSymbol))
+    resSym = eval(
+        _gen_access_expr(
+            entry_device(tape.machine),
+            entry_device(tape.machine).cacheStrategy,
+            tape.outputSymbol,
+        ),
+    )
     expr = #
     Expr(
         :function, # function definition

--- a/src/code_gen/tape_machine.jl
+++ b/src/code_gen/tape_machine.jl
@@ -212,13 +212,6 @@ function gen_function_body(tape::Tape; closures_size::Int)
 
         setdiff!(undefined_argument_symbols, ret_symbols_set)
 
-        #=Expr(
-            :macrocall,
-            Symbol("@closure"),
-            @__LINE__,
-            Expr( <closure...> )
-        )=#
-
         # combine to one closure call, including all the local inits and the actual call to the closure
         pushfirst!(closures, closure)
     end

--- a/src/code_gen/type.jl
+++ b/src/code_gen/type.jl
@@ -12,7 +12,7 @@ TODO: update docs
 struct Tape{INPUT}
     initCachesCode::Vector{Expr}
     inputAssignCode::Vector{FunctionCall}
-    computeCode::Vector{FunctionCall}
+    schedule::Vector{FunctionCall}
     inputSymbols::Dict{String,Vector{Symbol}}
     outputSymbol::Symbol
     cache::Dict{Symbol,Any}

--- a/src/code_gen/utils.jl
+++ b/src/code_gen/utils.jl
@@ -1,0 +1,45 @@
+"""
+    infer_types!(schedule::Vector{FunctionCall})
+
+Infer the result type of each function call in the given schedule. Returns a dictionary with the result type for each [`Node`](@ref). This assumes that each node has only one statically inferrable return type and will throw an exceptin otherwise.
+This also assumes that the given `Vector` contains a topological ordering of its nodes, such as returned by a call to [`schedule_dag`](@ref).
+"""
+function infer_types!(tape::Tape)
+    known_result_types = Dict{Symbol,Type}()
+
+    # the only initially known type
+    known_result_types[:input] = input_type(tape.instance)
+
+    for fc in tape.inputAssignCode
+        res_type = result_type(fc, known_result_types)
+        fc.return_type = res_type
+        known_result_types[fc.return_symbol] = res_type
+    end
+
+    for fc in tape.schedule
+        res_type = result_type(fc, known_result_types)
+        fc.return_type = res_type
+        known_result_types[fc.return_symbol] = res_type
+    end
+
+    return nothing
+end
+
+"""
+    lower(schedule::Vector{Node}, machine::Machine)
+
+After [`schedule_dag`](@ref) has made a schedule of nodes, this function lowers the vector of [`Node`](@ref)s into a vector of [`FunctionCall`](@ref)s.
+"""
+function lower(schedule::Vector{Node}, machine::Machine)
+    calls = Vector{FunctionCall}()
+
+    for node in schedule
+        if (node isa DataTaskNode && length(children(node)) == 0)
+            push!(calls, get_init_function_call(node, entry_device(machine)))
+        else
+            push!(calls, get_function_call(node)...)
+        end
+    end
+
+    return calls
+end

--- a/src/devices/impl.jl
+++ b/src/devices/impl.jl
@@ -62,3 +62,21 @@ function cpu_st()
         [NumaNode(0, 1, default_strategy(NumaNode), -1.0, UUIDs.uuid1())], [-1.0;;]
     )
 end
+
+"""
+    gen_access_expr(fc::FunctionCall)
+
+Dispatch from the given [`FunctionCall`](@ref) to the interface function `_gen_access_expr`(@ref).
+"""
+function gen_access_expr(fc::FunctionCall)
+    return _gen_access_expr(fc.device, fc.device.cacheStrategy, fc.return_symbol)
+end
+
+"""
+    gen_local_init(fc::FunctionCall)
+
+Dispatch from the given [`FunctionCall`](@ref) to the interface function `_gen_local_init`(@ref).
+"""
+function gen_local_init(fc::FunctionCall)
+    return _gen_local_init(fc, fc.device, fc.device.cacheStrategy)
+end

--- a/src/devices/interface.jl
+++ b/src/devices/interface.jl
@@ -100,12 +100,21 @@ The strategy is a symbol
 function gen_cache_init_code end
 
 """
-    gen_access_expr(device::AbstractDevice, symbol::Symbol)
+    _gen_access_expr(device::AbstractDevice, cache_strategy::CacheStrategy, symbol::Symbol)
 
 Interface function that must be implemented for every subtype of [`AbstractDevice`](@ref) and at least one [`CacheStrategy`](@ref).
 Return an `Expr` or `QuoteNode` accessing the variable identified by [`symbol`].
 """
-function gen_access_expr end
+function _gen_access_expr end
+
+"""
+    _gen_local_init(fc::FunctionCall, device::AbstractDevice, cache_strategy::CacheStrategy)
+
+Interface function that must be implemented for every subtype of [`AbstractDevice`](@ref) and at least one [`CacheStrategy`](@ref).
+Return an `Expr` or `QuoteNode` that initializes the access expression returned by [`_gen_access_expr`](@ref) in the local scope.
+This expression may be empty. For local variables it should be `local <variable_name>::<Type>`.
+"""
+function _gen_local_init end
 
 """
     kernel(gpu_type::Type{<:AbstractGPU}, graph::DAG, instance)

--- a/src/devices/numa/impl.jl
+++ b/src/devices/numa/impl.jl
@@ -94,7 +94,7 @@ Interface implementation, dispatched to from [`gen_local_init`](@ref).
 """
 function _gen_local_init(fc::FunctionCall, ::NumaNode, ::LocalVariables)
     s = Symbol("data_$(fc.return_symbol)")
-    quote_node = Expr(:local, s) # TODO: figure out how to get type info for this local variable
+    quote_node = Expr(:local, s, :(::), Symbol(fc.return_type)) # TODO: figure out how to get type info for this local variable
     return quote_node
 end
 

--- a/src/devices/numa/impl.jl
+++ b/src/devices/numa/impl.jl
@@ -64,32 +64,45 @@ function gen_cache_init_code(device::NumaNode)
 end
 
 """
-    gen_access_expr(device::NumaNode, symbol::Symbol)
-
-Generate code to access the variable designated by `symbol` on a [`NumaNode`](@ref), using the [`CacheStrategy`](@ref) set in the device.
-"""
-function gen_access_expr(device::NumaNode, symbol::Symbol)
-    return _gen_access_expr(device, device.cacheStrategy, symbol)
-end
-
-"""
     _gen_access_expr(device::NumaNode, ::LocalVariables, symbol::Symbol)
 
-Internal function for dispatch, used in [`gen_access_expr`](@ref).
+Interface implementation, dispatched to from [`gen_access_expr`](@ref).
 """
-function _gen_access_expr(device::NumaNode, ::LocalVariables, symbol::Symbol)
+function _gen_access_expr(::NumaNode, ::LocalVariables, symbol::Symbol)
+    # TODO rewrite these with Expr instead of quote node
     s = Symbol("data_$symbol")
-    quoteNode = Meta.parse(":($s)")
-    return quoteNode
+    quote_node = Meta.parse(":($s)")
+    return quote_node
 end
 
 """
     _gen_access_expr(device::NumaNode, ::Dictionary, symbol::Symbol)
 
-Internal function for dispatch, used in [`gen_access_expr`](@ref).
+Interface implementation, dispatched to from [`gen_access_expr`](@ref).
 """
 function _gen_access_expr(device::NumaNode, ::Dictionary, symbol::Symbol)
-    accessStr = ":(cache_$(to_var_name(device.id))[:$symbol])"
-    quoteNode = Meta.parse(accessStr)
-    return quoteNode
+    # TODO rewrite these with Expr instead of quote node
+    access_str = ":(cache_$(to_var_name(device.id))[:$symbol])"
+    quote_node = Meta.parse(access_str)
+    return quote_node
+end
+
+"""
+    _gen_local_init(fc::FunctionCall, device::NumaNode, cache_strategy::LocalVariables)
+
+Interface implementation, dispatched to from [`gen_local_init`](@ref).
+"""
+function _gen_local_init(fc::FunctionCall, ::NumaNode, ::LocalVariables)
+    s = Symbol("data_$(fc.return_symbol)")
+    quote_node = Expr(:local, s) # TODO: figure out how to get type info for this local variable
+    return quote_node
+end
+
+"""
+    _gen_local_init(fc::FunctionCall, device::NumaNode, cache_strategy::Dictionary)
+
+Interface implementation, dispatched to from [`gen_local_init`](@ref).
+"""
+function _gen_local_init(::FunctionCall, ::NumaNode, ::Dictionary)
+    return Exp()
 end

--- a/src/node/create.jl
+++ b/src/node/create.jl
@@ -1,4 +1,3 @@
-
 function DataTaskNode(t::AbstractDataTask, name="")
     return DataTaskNode(
         t,

--- a/src/scheduler/greedy.jl
+++ b/src/scheduler/greedy.jl
@@ -7,46 +7,42 @@ A greedy implementation of a scheduler, creating a topological ordering of nodes
 struct GreedyScheduler <: AbstractScheduler end
 
 function schedule_dag(::GreedyScheduler, graph::DAG, machine::Machine)
-    nodeQueue = PriorityQueue{Node,Int}()
+    node_queue = PriorityQueue{Node,Int}()
 
     # use a priority equal to the number of unseen children -> 0 are nodes that can be added
     for node in get_entry_nodes(graph)
-        enqueue!(nodeQueue, node => 0)
+        enqueue!(node_queue, node => 0)
     end
 
-    schedule = Vector{FunctionCall}()
+    schedule = Vector{Node}()
     sizehint!(schedule, length(graph.nodes))
 
     # keep an accumulated cost of things scheduled to this device so far
-    deviceAccCost = PriorityQueue{AbstractDevice,Float64}()
+    device_acc_cost = PriorityQueue{AbstractDevice,Float64}()
     for device in machine.devices
-        enqueue!(deviceAccCost, device => 0)
+        enqueue!(device_acc_cost, device => 0)
     end
 
-    node = nothing
-    while !isempty(nodeQueue)
-        @assert peek(nodeQueue)[2] == 0
-        node = dequeue!(nodeQueue)
+    local node
+    while !isempty(node_queue)
+        @assert peek(node_queue)[2] == 0
+        node = dequeue!(node_queue)
 
         # assign the device with lowest accumulated cost to the node (if it's a compute node)
         if (isa(node, ComputeTaskNode))
-            lowestDevice = peek(deviceAccCost)[1]
-            node.device = lowestDevice
-            deviceAccCost[lowestDevice] = compute_effort(task(node))
+            lowest_device = peek(device_acc_cost)[1]
+            node.device = lowest_device
+            device_acc_cost[lowest_device] = compute_effort(task(node))
         end
 
-        if (node isa DataTaskNode && length(children(node)) == 0)
-            push!(schedule, get_init_function_call(node, entry_device(machine)))
-        else
-            push!(schedule, get_function_call(node)...)
-        end
+        push!(schedule, node)
 
         for parent in parents(node)
             # reduce the priority of all parents by one
-            if (!haskey(nodeQueue, parent))
-                enqueue!(nodeQueue, parent => length(children(parent)) - 1)
+            if (!haskey(node_queue, parent))
+                enqueue!(node_queue, parent => length(children(parent)) - 1)
             else
-                nodeQueue[parent] = nodeQueue[parent] - 1
+                node_queue[parent] = node_queue[parent] - 1
             end
         end
     end

--- a/src/scheduler/interface.jl
+++ b/src/scheduler/interface.jl
@@ -15,6 +15,6 @@ The function assigns each [`ComputeTaskNode`](@ref) of the [`DAG`](@ref) to one 
 
 [`DataTaskNode`](@ref)s are not scheduled to devices since they do not compute. Instead, a data node transfers data from the [`AbstractDevice`](@ref) of their child to all [`AbstractDevice`](@ref)s of its parents.
 
-Return a `Vector{FunctionCall}`. See [`FunctionCall`](@ref)
+The produced schedule can be converted to [`FunctionCall`](@ref)s using [`lower`](@ref).
 """
 function schedule_dag end

--- a/src/scheduler/type.jl
+++ b/src/scheduler/type.jl
@@ -5,11 +5,12 @@ using StaticArrays
 
 Type representing a function call with `N` parameters. Contains the function to call, argument symbols, the return symbol and the device to execute on.
 """
-struct FunctionCall{VectorType<:AbstractVector,N}
+mutable struct FunctionCall{VectorType<:AbstractVector,N}
     func::Function
     # TODO: this should be a tuple
     value_arguments::SVector{N,Any}    # value arguments for the function call, will be prepended to the other arguments
-    arguments::VectorType               # symbols of the inputs to the function call
+    arguments::VectorType              # symbols of the inputs to the function call
     return_symbol::Symbol
+    return_type::Type
     device::AbstractDevice
 end

--- a/src/task/compute.jl
+++ b/src/task/compute.jl
@@ -81,6 +81,11 @@ function result_type(fc::FunctionCall, known_res_types::Dict{Symbol,Type})
             "failure during type inference: function call $fc is type unstable, possible return types: $types",
         )
     end
+    if isempty(types)
+        throw(
+            "failure during type inference: function call $fc has no return types, this is likely because no method matches the arguments",
+        )
+    end
 
     return types[1]
 end


### PR DESCRIPTION
Also removes the use of RuntimeGeneratedFunctions inside the generated function itself.

This adds the use of closures to reduce compile times.

Still todo:
- [x] Make closures more optional, off by default
- [ ] Add automatic closure size
- [ ] Make closures recursively available so even larger functions can be generated
- [ ] Improve function generation performance, currently it is very slow, likely because of heavy usage of sets
- [x] Investigate how to improve the runtime performance of the generated functions when using closures. The current problem is likely too many allocations.

Fixes #33