### PR TITLE
Rework FunctionCalls to allow multiple returned objects

### DIFF
--- a/ext/devices/cuda/function.jl
+++ b/ext/devices/cuda/function.jl
@@ -20,7 +20,7 @@ function ComputableDAGs.kernel(
             if (id > n)  
                 return
             end
-            @inline data_input = input_vector[id]
+            @inline input = input_vector[id]
             $(assign_inputs)
             $code
             @inline output_vector[id] = $res_sym

--- a/ext/devices/cuda/function.jl
+++ b/ext/devices/cuda/function.jl
@@ -9,11 +9,6 @@ function ComputableDAGs.kernel(
     code = Expr(:block, ComputableDAGs.expr_from_fc.(tape.schedule)...)
 
     function_id = ComputableDAGs.to_var_name(UUIDs.uuid1(ComputableDAGs.rng[1]))
-    res_sym = eval(
-        ComputableDAGs._gen_access_expr(
-            ComputableDAGs.entry_device(tape.machine), tape.output_symbol
-        ),
-    )
     expr = Meta.parse(
         "function compute_$(function_id)(input_vector, output_vector, n::Int64)
             id = (blockIdx().x - 1) * blockDim().x + threadIdx().x
@@ -23,7 +18,7 @@ function ComputableDAGs.kernel(
             @inline input = input_vector[id]
             $(assign_inputs)
             $code
-            @inline output_vector[id] = $res_sym
+            @inline output_vector[id] = $(tape.output_symbol)
             return nothing
         end"
     )

--- a/ext/devices/cuda/function.jl
+++ b/ext/devices/cuda/function.jl
@@ -4,14 +4,14 @@ function ComputableDAGs.kernel(
     machine = cpu_st()
     tape = ComputableDAGs.gen_tape(graph, instance, machine, context_module)
 
-    assign_inputs = Expr(:block, ComputableDAGs.expr_from_fc.(tape.inputAssignCode)...)
+    assign_inputs = Expr(:block, ComputableDAGs.expr_from_fc.(tape.input_assign_code)...)
     # TODO: use gen_function_body here
     code = Expr(:block, ComputableDAGs.expr_from_fc.(tape.schedule)...)
 
     function_id = ComputableDAGs.to_var_name(UUIDs.uuid1(ComputableDAGs.rng[1]))
     res_sym = eval(
         ComputableDAGs._gen_access_expr(
-            ComputableDAGs.entry_device(tape.machine), tape.outputSymbol
+            ComputableDAGs.entry_device(tape.machine), tape.output_symbol
         ),
     )
     expr = Meta.parse(

--- a/ext/devices/rocm/function.jl
+++ b/ext/devices/rocm/function.jl
@@ -4,7 +4,7 @@ function ComputableDAGs.kernel(
     machine = cpu_st()
     tape = ComputableDAGs.gen_tape(graph, instance, machine, context_module)
 
-    assign_inputs = Expr(:block, ComputableDAGs.expr_from_fc.(tape.inputAssignCode)...)
+    assign_inputs = Expr(:block, ComputableDAGs.expr_from_fc.(tape.input_assign_code)...)
 
     # TODO use gen_function_body here
     code = Expr(:block, ComputableDAGs.expr_from_fc.(tape.schedule)...)
@@ -12,7 +12,7 @@ function ComputableDAGs.kernel(
     function_id = ComputableDAGs.to_var_name(UUIDs.uuid1(ComputableDAGs.rng[1]))
     res_sym = eval(
         ComputableDAGs._gen_access_expr(
-            ComputableDAGs.entry_device(tape.machine), tape.outputSymbol
+            ComputableDAGs.entry_device(tape.machine), tape.output_symbol
         ),
     )
     expr = Meta.parse(

--- a/ext/devices/rocm/function.jl
+++ b/ext/devices/rocm/function.jl
@@ -21,7 +21,7 @@ function ComputableDAGs.kernel(
             if (id > n)
                 return
             end
-            @inline data_input = input_vector[id]
+            @inline input = input_vector[id]
             $(assign_inputs)
             $code
             @inline output_vector[id] = $res_sym

--- a/ext/devices/rocm/function.jl
+++ b/ext/devices/rocm/function.jl
@@ -10,11 +10,6 @@ function ComputableDAGs.kernel(
     code = Expr(:block, ComputableDAGs.expr_from_fc.(tape.schedule)...)
 
     function_id = ComputableDAGs.to_var_name(UUIDs.uuid1(ComputableDAGs.rng[1]))
-    res_sym = eval(
-        ComputableDAGs._gen_access_expr(
-            ComputableDAGs.entry_device(tape.machine), tape.output_symbol
-        ),
-    )
     expr = Meta.parse(
         "function compute_$(function_id)(input_vector, output_vector, n::Int64)
             id = (workgroupIdx().x - 1) * workgroupDim().x + workgroupIdx().x
@@ -24,7 +19,7 @@ function ComputableDAGs.kernel(
             @inline input = input_vector[id]
             $(assign_inputs)
             $code
-            @inline output_vector[id] = $res_sym
+            @inline output_vector[id] = $(tape.output_symbol)
             return nothing
         end"
     )

--- a/src/ComputableDAGs.jl
+++ b/src/ComputableDAGs.jl
@@ -37,7 +37,6 @@ export get_operations
 export execute
 export get_compute_function
 export gen_tape, execute_tape
-export unpack_identity
 
 # estimator
 export cost_type, graph_cost, operation_effect

--- a/src/ComputableDAGs.jl
+++ b/src/ComputableDAGs.jl
@@ -34,9 +34,8 @@ export reset_graph!
 export get_operations
 
 # code generation related
-export execute
 export get_compute_function
-export gen_tape, execute_tape
+export gen_tape
 
 # estimator
 export cost_type, graph_cost, operation_effect

--- a/src/ComputableDAGs.jl
+++ b/src/ComputableDAGs.jl
@@ -35,7 +35,6 @@ export get_operations
 
 # code generation related
 export get_compute_function
-export gen_tape
 
 # estimator
 export cost_type, graph_cost, operation_effect
@@ -48,8 +47,7 @@ export optimize_step!, optimize!
 export fixpoint_reached, optimize_to_fixpoint!
 
 # models
-export AbstractModel, AbstractProblemInstance
-export problem_instance, input_type, graph, input_expr
+export graph, input_type, input_expr
 
 # machine info
 export Machine
@@ -67,6 +65,7 @@ include("properties/type.jl")
 include("operation/type.jl")
 include("graph/type.jl")
 include("scheduler/type.jl")
+include("code_gen/type.jl")
 
 include("trie.jl")
 include("utils.jl")
@@ -125,7 +124,6 @@ include("devices/ext.jl")
 include("scheduler/interface.jl")
 include("scheduler/greedy.jl")
 
-include("code_gen/type.jl")
 include("code_gen/utils.jl")
 include("code_gen/tape_machine.jl")
 include("code_gen/function.jl")

--- a/src/code_gen/function.jl
+++ b/src/code_gen/function.jl
@@ -40,25 +40,3 @@ function get_compute_function(
 
     return RuntimeGeneratedFunction(@__MODULE__, context_module, expr)
 end
-
-"""
-    execute(
-        graph::DAG,
-        instance,
-        machine::Machine,
-        input,
-        context_module::Module
-    )
-
-Execute the code of the given `graph` on the given input values.
-
-This is essentially shorthand for
-```julia
-tape = gen_tape(graph, instance, machine, context_module)
-return execute_tape(tape, input)
-```
-"""
-function execute(graph::DAG, instance, machine::Machine, input, context_module::Module)
-    tape = gen_tape(graph, instance, machine, context_module)
-    return execute_tape(tape, input)
-end

--- a/src/code_gen/function.jl
+++ b/src/code_gen/function.jl
@@ -27,13 +27,12 @@ function get_compute_function(
 )
     tape = gen_tape(graph, instance, machine, context_module)
 
-    assign_inputs = Expr(:block, expr_from_fc.(tape.input_assign_code)...)
     code = gen_function_body(tape, context_module; closures_size=closures_size)
+    assign_inputs = Expr(:block, expr_from_fc.(tape.input_assign_code)...)
 
     function_id = to_var_name(UUIDs.uuid1(rng[1]))
     res_sym = tape.output_symbol
-    expr = #
-    Expr(
+    expr = Expr(
         :function, # function definition
         Expr(
             :call, Symbol("compute_$function_id"), Expr(:(::), :input, input_type(instance))

--- a/src/code_gen/function.jl
+++ b/src/code_gen/function.jl
@@ -25,7 +25,7 @@ function get_compute_function(
     tape = gen_tape(graph, instance, machine, context_module)
 
     assign_inputs = Expr(:block, expr_from_fc.(tape.input_assign_code)...)
-    code = gen_function_body(tape; closures_size=closures_size)
+    code = gen_function_body(tape, context_module; closures_size=closures_size)
 
     function_id = to_var_name(UUIDs.uuid1(rng[1]))
     res_sym = _gen_access_expr(entry_device(tape.machine), tape.output_symbol)
@@ -33,9 +33,7 @@ function get_compute_function(
     Expr(
         :function, # function definition
         Expr(
-            :call,
-            Symbol("compute_$function_id"),
-            Expr(:(::), :data_input, input_type(instance)),
+            :call, Symbol("compute_$function_id"), Expr(:(::), :input, input_type(instance))
         ), # function name and parameters
         Expr(:block, assign_inputs, code, Expr(:return, res_sym)), # function body
     )

--- a/src/code_gen/function.jl
+++ b/src/code_gen/function.jl
@@ -24,20 +24,20 @@ function get_compute_function(
 )
     tape = gen_tape(graph, instance, machine, context_module)
 
-    assignInputs = Expr(:block, expr_from_fc.(tape.inputAssignCode)...)
+    assign_inputs = Expr(:block, expr_from_fc.(tape.input_assign_code)...)
     code = gen_function_body(tape; closures_size=closures_size)
 
-    functionId = to_var_name(UUIDs.uuid1(rng[1]))
-    resSym = eval(_gen_access_expr(entry_device(tape.machine), tape.outputSymbol))
+    function_id = to_var_name(UUIDs.uuid1(rng[1]))
+    res_sym = _gen_access_expr(entry_device(tape.machine), tape.output_symbol)
     expr = #
     Expr(
         :function, # function definition
         Expr(
             :call,
-            Symbol("compute_$functionId"),
+            Symbol("compute_$function_id"),
             Expr(:(::), :data_input, input_type(instance)),
         ), # function name and parameters
-        Expr(:block, assignInputs, code, Expr(:return, resSym)), # function body
+        Expr(:block, assign_inputs, code, Expr(:return, res_sym)), # function body
     )
 
     return RuntimeGeneratedFunction(@__MODULE__, context_module, expr)

--- a/src/code_gen/function.jl
+++ b/src/code_gen/function.jl
@@ -17,7 +17,10 @@ in your top level.
 
 ## Keyword Arguments
 
-`closures_size` (default=0 (off)): The size of closures to use in the main generated code. This specifies the size of code blocks across which the compiler cannot optimize. For sufficiently large functions, a larger value means longer compile times but potentially faster execution time.
+`closures_size` (default=0 (off)): The size of closures to use in the main generated code. This specifies the size of code blocks across which the 
+        compiler cannot optimize. For sufficiently large functions, a larger value means longer compile times but potentially faster execution time.
+        **Note** that the actually used closure size might be different than the one passed here, since the function automatically chooses a size that
+        is close to a n-th root of the total number of loc, based off the given size.
 """
 function get_compute_function(
     graph::DAG, instance, machine::Machine, context_module::Module; closures_size=0
@@ -28,7 +31,7 @@ function get_compute_function(
     code = gen_function_body(tape, context_module; closures_size=closures_size)
 
     function_id = to_var_name(UUIDs.uuid1(rng[1]))
-    res_sym = _gen_access_expr(entry_device(tape.machine), tape.output_symbol)
+    res_sym = tape.output_symbol
     expr = #
     Expr(
         :function, # function definition

--- a/src/code_gen/tape_machine.jl
+++ b/src/code_gen/tape_machine.jl
@@ -1,11 +1,6 @@
 function expr_from_fc(fc::FunctionCall{VAL_T,F_T}) where {VAL_T,F_T<:Function}
     if length(fc) == 1
-        func_call = Expr(
-            :call,
-            fc.func,
-            fc.value_arguments[1]...,
-            _gen_access_expr.(Ref(fc.device), fc.arguments[1])...,
-        )
+        func_call = Expr(:call, fc.func, fc.value_arguments[1]..., fc.arguments[1]...)
     else
         # TBW; dispatch to device specific vectorization
         throw("unimplemented")

--- a/src/code_gen/tape_machine.jl
+++ b/src/code_gen/tape_machine.jl
@@ -1,3 +1,4 @@
+#=
 # TODO: do this with macros
 function call_fc(
     fc::FunctionCall{VectorT,0}, cache::Dict{Symbol,Any}
@@ -49,8 +50,9 @@ function call_fc(fc::FunctionCall{VectorT,M}, cache::Dict{Symbol,Any}) where {Ve
     )
     return nothing
 end
+=#
 
-function expr_from_fc(fc::FunctionCall{VAL_T,N_ARG,N_RET}) where {VAL_T,N_ARG,N_RET}
+function expr_from_fc(fc::FunctionCall{VAL_T}) where {VAL_T}
     if length(fc) == 1
         func_call = Expr(
             :call,
@@ -92,9 +94,9 @@ function gen_input_assignment_code(
             fc = FunctionCall(
                 context_module.eval(Expr(:->, :x, input_expr(instance, name, :x))),
                 (),
-                (:input,),
-                (symbol,),
-                (Nothing,),
+                [:input],
+                [symbol],
+                [Nothing],
                 device,
             )
 
@@ -203,8 +205,8 @@ function _closure_fc(
     setdiff!(arg_symbols_set, ret_symbols_set)
     intersect!(ret_symbols_set, undefined_argument_symbols)
 
-    arg_symbols_t = (arg_symbols_set...,)
-    ret_symbols_t = (ret_symbols_set...,)
+    arg_symbols_t = [arg_symbols_set...]
+    ret_symbols_t = [ret_symbols_set...]
 
     closure = context_module.eval(
         Expr(                                   # create the closure: () -> code block; return (locals)

--- a/src/code_gen/type.jl
+++ b/src/code_gen/type.jl
@@ -6,14 +6,12 @@ TODO: update docs
 - `INPUT` the input type of the problem instance
 
 - `code::Vector{Expr}`: The julia expression containing the code for the whole graph.
-- `inputSymbols::Dict{String, Vector{Symbol}}`: A dictionary of symbols mapping the names of the input nodes of the graph to the symbols their inputs should be provided on.
-- `outputSymbol::Symbol`: The symbol of the final calculated value
+- `output_symbol::Symbol`: The symbol of the final calculated value
 """
 struct Tape{INPUT}
-    inputAssignCode::Vector{FunctionCall}
+    input_assign_code::Vector{FunctionCall}
     schedule::Vector{FunctionCall}
-    inputSymbols::Dict{String,Vector{Symbol}}
-    outputSymbol::Symbol
+    output_symbol::Symbol
     instance::Any
     machine::Machine
 end

--- a/src/code_gen/type.jl
+++ b/src/code_gen/type.jl
@@ -1,12 +1,76 @@
+"""
+    FunctionCall{VAL_T<:Tuple,FUNC_T<:Union{Function,Expr}}
+
+Representation of a function call. Contains the function to call (or an expression of a value to assign),
+value arguments of type `VAL_T`, argument symbols, the return symbol(s) and type(s) and the device to execute on.
+
+To support vectorization, i.e., calling the same function on multiple inputs (SIMD), the value arguments, arguments,
+and return symbols are each vectors of the actual inputs. In the non-vectorized case, these `Vector`s simply always
+have length 1. For this common case, a special constructor exists which automatically wraps each of these arguments
+in a `Vector`.
+
+## Type Arguments
+- `VAL_T<:Tuple`: A tuple of all the value arguments that are passed to the function when it's called.
+- `FUNC_T<:Union{Function, Expr}`: The type of the function. `Function` is the default, but in some cases, an `Expr`
+    of a value can be necessary to assign to the return symbol. In this case, no arguments are allowed.
+
+## Fields
+- `func::FUNC_T`: The function to be called, or an expression containing a value to assign to the return_symbol.
+- `value_arguments::Vector{VAL_T}`: The value arguments for the function call. These are passed *first* to the
+    function, in the order given here. The `Vector` contains the tuple of value arguments for each vectorization
+    member.
+- `arguments::Vector{Vector{Symbol}}`: The first vector represents the vectorization, the second layer represents the
+    symbols that will be passed as arguments to the function call.
+- `return_symbols::Vector{Vector{Symbol}}`: As with the arguments, the first vector level represents the vectorization,
+    the second represents the symbols that the results of the function call are assigned to. For most function calls,
+    there is only one return symbol. When using closures when generating a function body for a [`Tape`](@ref), the
+    option to have multiple return symbols is necessary.
+- `return_types::Vector{<:Type}`: The types of the function call with the arguments provided. This field only contains
+    one level of Vector, because it is required that a `FunctionCall` is type stable, and therefore, the types of the
+    return symbols have to be equal for all members of a vectorization. The return type is initially set to `Nothing`
+    and later inferred and assigned by [`infer_types!`](@ref).
+- `device::AbstractDevice`: The device that this function call is scheduled on.
+"""
+mutable struct FunctionCall{VAL_T<:Tuple,FUNC_T<:Union{Function,Expr}}
+    func::FUNC_T
+    value_arguments::Vector{VAL_T}          # tuple of value arguments for the function call, will be prepended to the other arguments
+    arguments::Vector{Vector{Symbol}}       # symbols of the inputs to the function call
+    return_symbols::Vector{Vector{Symbol}}  # the return symbols
+    return_types::Vector{<:Type}            # the return type of the function call(s); there can only be one return type since we require type stability
+    device::AbstractDevice
+end
+function FunctionCall(
+    func::Union{Function,Expr},
+    value_arguments::VAL_T,
+    arguments::Vector{Symbol},
+    return_symbol::Vector{Symbol},
+    return_types::Vector{<:Type},
+    device::AbstractDevice,
+) where {VAL_T<:Tuple}
+    # convenience constructor for function calls that do not use vectorization, which is most of the use cases
+    @assert length(return_types) == 0 || length(return_types) == length(return_symbol) "number of return types '$(length(return_types))' does not match the number of return symbols '$(length(return_symbol))'"
+    @assert func isa Function || length(value_arguments) == 0 "no value arguments are allowed for a an Expr FunctionCall, but got '$value_arguments'"
+    return FunctionCall(
+        func, [value_arguments], [arguments], [return_symbol], return_types, device
+    )
+end
 
 """
     Tape{INPUT}
 
-TODO: update docs
-- `INPUT` the input type of the problem instance
+Lowered representation of a computation, generated from a [`DAG`](@ref) through [`gen_tape`](@ref).
 
-- `code::Vector{Expr}`: The julia expression containing the code for the whole graph.
-- `output_symbol::Symbol`: The symbol of the final calculated value
+- `INPUT` the input type of the problem instance, see also the interface function [`input_type`](@ref)
+
+## Fields
+- `input_assign_code::Vector{FunctionCall}`: The [`FunctionCall`](@ref)s representing the input assignments,
+    mapping part of the input of the computation to each DAG entry node. These functions are generated using
+    the interface function [`input_expr`](@ref).
+- `schedule::Vector{FunctionCall}`: The [`FunctionCall`](@ref)s representing the function body of the computation.
+    There is one function call for each node in the [`DAG`](@ref).
+- `output_symbol::Symbol`: The symbol of the final calculated value, which is returned.
+- `instance::Any`: The instance that this tape is generated for.
+- `machine::Machine`: The [`Machine`](@ref) that this tape is generated for.
 """
 struct Tape{INPUT}
     input_assign_code::Vector{FunctionCall}

--- a/src/code_gen/utils.jl
+++ b/src/code_gen/utils.jl
@@ -17,6 +17,7 @@ function infer_types!(tape::Tape, context_module::Module)
 
     for fc in tape.input_assign_code
         res_types = result_types(fc, known_result_types, context_module)
+        fc.return_types = res_types
         for (s, t) in Iterators.zip(
             Iterators.flatten(fc.return_symbols),
             Iterators.cycle(res_types, length(fc.return_symbols)),

--- a/src/code_gen/utils.jl
+++ b/src/code_gen/utils.jl
@@ -1,23 +1,22 @@
-"""
-    infer_types!(schedule::Vector{FunctionCall})
+function Base.length(fc::FunctionCall)
+    @assert length(fc.value_arguments) == length(fc.arguments) == length(fc.return_symbols) "function call length is undefined, got '$(length(fc.value_arguments))' tuples of value arguments, '$(length(fc.arguments))' tuples of arguments, and '$(length(return_symbols))' return symbols"
+    return length(fc.value_arguments)
+end
 
-Infer the result type of each function call in the given schedule. Returns a dictionary with the result type for each [`Node`](@ref). This assumes that each node has only one statically inferrable return type and will throw an exceptin otherwise.
-This also assumes that the given `Vector` contains a topological ordering of its nodes, such as returned by a call to [`schedule_dag`](@ref).
-
-Also returns the inferred types as a `Dict{Symbol, Type}`.
 """
-function infer_types!(tape::Tape)
+    infer_types!(tape::Tape, context_module::Module)
+
+Infer the result type of each function call in the given tape. Returns a dictionary with the result type for each symbol and sets each function call's return_types.
+This function assumes that each [`FunctionCall`](@ref) has only one statically inferrable return type and will throw an exception otherwise.
+"""
+function infer_types!(tape::Tape, context_module::Module)
     known_result_types = Dict{Symbol,Type}()
 
     # the only initially known type
     known_result_types[:input] = input_type(tape.instance)
 
     for fc in tape.input_assign_code
-        if typeof(fc.func) isa Expr
-            continue
-        end
-        # for input assign code, the return types are set on construction
-        res_types = fc.return_types
+        res_types = result_types(fc, known_result_types, context_module)
         for (s, t) in Iterators.zip(
             Iterators.flatten(fc.return_symbols),
             Iterators.cycle(res_types, length(fc.return_symbols)),
@@ -27,7 +26,7 @@ function infer_types!(tape::Tape)
     end
 
     for fc in tape.schedule
-        res_types = result_types(fc, known_result_types)
+        res_types = result_types(fc, known_result_types, context_module)
         fc.return_types = res_types
         for (s, t) in Iterators.zip(
             Iterators.flatten(fc.return_symbols),

--- a/src/code_gen/utils.jl
+++ b/src/code_gen/utils.jl
@@ -13,8 +13,11 @@ function infer_types!(tape::Tape)
     known_result_types[:input] = input_type(tape.instance)
 
     for fc in tape.input_assign_code
-        res_types = result_types(fc, known_result_types)
-        fc.return_types = res_types
+        if typeof(fc.func) isa Expr
+            continue
+        end
+        # for input assign code, the return types are set on construction
+        res_types = fc.return_types
         for (s, t) in Iterators.zip(
             Iterators.flatten(fc.return_symbols),
             Iterators.cycle(res_types, length(fc.return_symbols)),

--- a/src/code_gen/utils.jl
+++ b/src/code_gen/utils.jl
@@ -3,6 +3,8 @@
 
 Infer the result type of each function call in the given schedule. Returns a dictionary with the result type for each [`Node`](@ref). This assumes that each node has only one statically inferrable return type and will throw an exceptin otherwise.
 This also assumes that the given `Vector` contains a topological ordering of its nodes, such as returned by a call to [`schedule_dag`](@ref).
+
+Also returns the inferred types as a `Dict{Symbol, Type}`.
 """
 function infer_types!(tape::Tape)
     known_result_types = Dict{Symbol,Type}()
@@ -32,7 +34,7 @@ function infer_types!(tape::Tape)
         end
     end
 
-    return nothing
+    return known_result_types
 end
 
 """

--- a/src/devices/impl.jl
+++ b/src/devices/impl.jl
@@ -63,9 +63,6 @@ end
     gen_local_init(fc::FunctionCall)
 
 Dispatch from the given [`FunctionCall`](@ref) to the lower-level function [`_gen_local_init`](@ref).
-
-!!! note
-    This is currently unused, but may become useful in the future again.
 """
 function gen_local_init(fc::FunctionCall)
     return Expr(
@@ -82,10 +79,26 @@ end
 
 Return an `Expr` that initializes the symbol in the local scope.
 The result looks like `local <symbol>::<type>`.
-
-!!! note
-    This is currently unused, but may become useful in the future again.
 """
 function _gen_local_init(symbol::Symbol, type::Type)
     return Expr(:local, symbol, :(::), Symbol(type))
+end
+
+"""
+    wrap_in_let_statement(expr, symbols)
+
+For a given expression and a collection of symbols, generate a let statement that wraps the expression in a let statement with all the symbols, like
+`let <symbol[1]>=<symbol[1]>, ..., <symbol[end]>=<symbol[end]> <expr> end`
+"""
+@inline function wrap_in_let_statement(expr, symbols)
+    return Expr(:let, Expr(:block, _gen_let_statement.(symbols)...), expr)
+end
+
+"""
+    _gen_let_statement(symbol::Symbol)
+
+Return a let-`Expr` like `<symbol> = <symbol>`.
+"""
+function _gen_let_statement(symbol::Symbol)
+    return Expr(:(=), symbol, symbol)
 end

--- a/src/devices/interface.jl
+++ b/src/devices/interface.jl
@@ -47,23 +47,6 @@ Interface function that must be implemented for every subtype of [`AbstractDevic
 function measure_device! end
 
 """
-    _gen_access_expr(device::AbstractDevice, symbol::Symbol)
-
-Interface function that must be implemented for every subtype of [`AbstractDevice`](@ref).
-Return an `Expr` or `QuoteNode` accessing the variable identified by [`symbol`].
-"""
-function _gen_access_expr end
-
-"""
-    _gen_local_init(device::AbstractDevice, symbol::Symbol, type::Type)
-
-Interface function that must be implemented for every subtype of [`AbstractDevice`](@ref).
-Return an `Expr` or `QuoteNode` that initializes the access expression returned by [`_gen_access_expr`](@ref) in the local scope.
-This expression may be empty. For local variables it should be `local <variable_name>::<Type>`.
-"""
-function _gen_local_init end
-
-"""
     kernel(gpu_type::Type{<:AbstractGPU}, graph::DAG, instance)
 
 For a GPU type, a [`DAG`](@ref), and a problem instance, return an `Expr` containing a function of signature `compute_<id>(input::<GPU>Vector, output::<GPU>Vector, n::Int64)`, which will return the result of the DAG computation of the input on the given output vector, intended for computation on GPUs. Currently, `CUDAGPU` and `ROCmGPU` are available if their respective package extensions are loaded.

--- a/src/devices/interface.jl
+++ b/src/devices/interface.jl
@@ -55,7 +55,7 @@ Return an `Expr` or `QuoteNode` accessing the variable identified by [`symbol`].
 function _gen_access_expr end
 
 """
-    _gen_local_init(fc::FunctionCall, device::AbstractDevice)
+    _gen_local_init(device::AbstractDevice, symbol::Symbol, type::Type)
 
 Interface function that must be implemented for every subtype of [`AbstractDevice`](@ref).
 Return an `Expr` or `QuoteNode` that initializes the access expression returned by [`_gen_access_expr`](@ref) in the local scope.

--- a/src/devices/numa/impl.jl
+++ b/src/devices/numa/impl.jl
@@ -46,9 +46,9 @@ Interface implementation, dispatched to from [`gen_access_expr`](@ref).
 """
 function _gen_access_expr(::NumaNode, symbol::Symbol)
     # TODO rewrite these with Expr instead of quote node
-    s = Symbol("data_$symbol")
-    quote_node = Meta.parse(":($s)")
-    return eval(quote_node)
+    #=s = Symbol("data_$symbol")
+    quote_node = Meta.parse(":($s)")=#
+    return symbol
 end
 
 """
@@ -57,7 +57,7 @@ end
 Interface implementation, dispatched to from [`gen_local_init`](@ref).
 """
 function _gen_local_init(::NumaNode, symbol::Symbol, type::Type)
-    s = Symbol("data_$(symbol)")
-    quote_node = Expr(:local, s, :(::), Symbol(type))
+    #s = Symbol("data_$(symbol)")
+    quote_node = Expr(:local, symbol, :(::), Symbol(type))
     return quote_node
 end

--- a/src/devices/numa/impl.jl
+++ b/src/devices/numa/impl.jl
@@ -48,16 +48,16 @@ function _gen_access_expr(::NumaNode, symbol::Symbol)
     # TODO rewrite these with Expr instead of quote node
     s = Symbol("data_$symbol")
     quote_node = Meta.parse(":($s)")
-    return quote_node
+    return eval(quote_node)
 end
 
 """
-    _gen_local_init(fc::FunctionCall, device::NumaNode)
+    _gen_local_init(device::NumaNode, symbol::Symbol, type::Type)
 
 Interface implementation, dispatched to from [`gen_local_init`](@ref).
 """
-function _gen_local_init(fc::FunctionCall, ::NumaNode)
-    s = Symbol("data_$(fc.return_symbol)")
-    quote_node = Expr(:local, s, :(::), Symbol(fc.return_type)) # TODO: figure out how to get type info for this local variable
+function _gen_local_init(::NumaNode, symbol::Symbol, type::Type)
+    s = Symbol("data_$(symbol)")
+    quote_node = Expr(:local, s, :(::), Symbol(type))
     return quote_node
 end

--- a/src/devices/numa/impl.jl
+++ b/src/devices/numa/impl.jl
@@ -38,26 +38,3 @@ function get_devices(deviceType::Type{T}; verbose::Bool=false) where {T<:NumaNod
 
     return devices
 end
-
-"""
-    _gen_access_expr(device::NumaNode, symbol::Symbol)
-
-Interface implementation, dispatched to from [`gen_access_expr`](@ref).
-"""
-function _gen_access_expr(::NumaNode, symbol::Symbol)
-    # TODO rewrite these with Expr instead of quote node
-    #=s = Symbol("data_$symbol")
-    quote_node = Meta.parse(":($s)")=#
-    return symbol
-end
-
-"""
-    _gen_local_init(device::NumaNode, symbol::Symbol, type::Type)
-
-Interface implementation, dispatched to from [`gen_local_init`](@ref).
-"""
-function _gen_local_init(::NumaNode, symbol::Symbol, type::Type)
-    #s = Symbol("data_$(symbol)")
-    quote_node = Expr(:local, symbol, :(::), Symbol(type))
-    return quote_node
-end

--- a/src/estimator/global_metric.jl
+++ b/src/estimator/global_metric.jl
@@ -5,40 +5,40 @@ Representation of a [`DAG`](@ref)'s cost as estimated by the [`GlobalMetricEstim
 
 # Fields:
 `.data`: The total data transfer.\\
-`.computeEffort`: The total compute effort.\\
-`.computeIntensity`: The compute intensity, will always equal `.computeEffort / .data`.
+`.compute_effort`: The total compute effort.\\
+`.compute_intensity`: The compute intensity, will always equal `.compute_effort / .data`.
 
 
 !!! note
-    Note that the `computeIntensity` doesn't necessarily make sense in the context of only operation costs.
+    Note that the `compute_intensity` doesn't necessarily make sense in the context of only operation costs.
     It will still work as intended when adding/subtracting to/from a `graph_cost` estimate.
 """
 const CDCost = NamedTuple{
-    (:data, :computeEffort, :computeIntensity),Tuple{Float64,Float64,Float64}
+    (:data, :compute_effort, :compute_intensity),Tuple{Float64,Float64,Float64}
 }
 
 function Base.:+(cost1::CDCost, cost2::CDCost)::CDCost
     d = cost1.data + cost2.data
-    ce = computeEffort = cost1.computeEffort + cost2.computeEffort
-    return (data=d, computeEffort=ce, computeIntensity=ce / d)::CDCost
+    ce = compute_effort = cost1.compute_effort + cost2.compute_effort
+    return (data=d, compute_effort=ce, compute_intensity=ce / d)::CDCost
 end
 
 function Base.:-(cost1::CDCost, cost2::CDCost)::CDCost
     d = cost1.data - cost2.data
-    ce = computeEffort = cost1.computeEffort - cost2.computeEffort
-    return (data=d, computeEffort=ce, computeIntensity=ce / d)::CDCost
+    ce = compute_effort = cost1.compute_effort - cost2.compute_effort
+    return (data=d, compute_effort=ce, compute_intensity=ce / d)::CDCost
 end
 
 function Base.isless(cost1::CDCost, cost2::CDCost)::Bool
-    return cost1.data + cost1.computeEffort < cost2.data + cost2.computeEffort
+    return cost1.data + cost1.compute_effort < cost2.data + cost2.compute_effort
 end
 
 function Base.zero(type::Type{CDCost})
-    return (data=0.0, computeEffort=0.0, computeIntensity=0.0)::CDCost
+    return (data=0.0, compute_effort=0.0, compute_intensity=0.0)::CDCost
 end
 
 function Base.typemax(type::Type{CDCost})
-    return (data=Inf, computeEffort=Inf, computeIntensity=0.0)::CDCost
+    return (data=Inf, compute_effort=Inf, compute_intensity=0.0)::CDCost
 end
 
 """
@@ -56,8 +56,8 @@ function graph_cost(estimator::GlobalMetricEstimator, graph::DAG)
     properties = get_properties(graph)
     return (
         data=properties.data,
-        computeEffort=properties.computeEffort,
-        computeIntensity=properties.computeIntensity,
+        compute_effort=properties.compute_effort,
+        compute_intensity=properties.compute_intensity,
     )::CDCost
 end
 
@@ -67,8 +67,8 @@ function operation_effect(
     s = length(operation.input) - 1
     return (
         data=s * -data(task(operation.input[1])),
-        computeEffort=s * -compute_effort(task(operation.input[1])),
-        computeIntensity=typeof(operation.input) <: DataTaskNode ? 0.0 : Inf,
+        compute_effort=s * -compute_effort(task(operation.input[1])),
+        compute_intensity=typeof(operation.input) <: DataTaskNode ? 0.0 : Inf,
     )::CDCost
 end
 
@@ -78,7 +78,7 @@ function operation_effect(
     s::Float64 = length(parents(operation.input)) - 1
     d::Float64 = s * data(task(operation.input))
     ce::Float64 = s * compute_effort(task(operation.input))
-    return (data=d, computeEffort=ce, computeIntensity=ce / d)::CDCost
+    return (data=d, compute_effort=ce, compute_intensity=ce / d)::CDCost
 end
 
 function String(::GlobalMetricEstimator)

--- a/src/graph/interface.jl
+++ b/src/graph/interface.jl
@@ -7,7 +7,7 @@ See also: [`DAG`](@ref), [`pop_operation!`](@ref)
 """
 function push_operation!(graph::DAG, operation::Operation)
     # 1.: Add the operation to the DAG
-    push!(graph.operationsToApply, operation)
+    push!(graph.operations_to_apply, operation)
 
     return nothing
 end
@@ -21,10 +21,10 @@ See also: [`DAG`](@ref), [`push_operation!`](@ref)
 """
 function pop_operation!(graph::DAG)
     # 1.: Remove the operation from the appliedChain of the DAG
-    if !isempty(graph.operationsToApply)
-        pop!(graph.operationsToApply)
-    elseif !isempty(graph.appliedOperations)
-        appliedOp = pop!(graph.appliedOperations)
+    if !isempty(graph.operations_to_apply)
+        pop!(graph.operations_to_apply)
+    elseif !isempty(graph.applied_operations)
+        appliedOp = pop!(graph.applied_operations)
         revert_operation!(graph, appliedOp)
     else
         error("No more operations to pop!")
@@ -38,7 +38,8 @@ end
 
 Return `true` if [`pop_operation!`](@ref) is possible, `false` otherwise.
 """
-can_pop(graph::DAG) = !isempty(graph.operationsToApply) || !isempty(graph.appliedOperations)
+can_pop(graph::DAG) =
+    !isempty(graph.operations_to_apply) || !isempty(graph.applied_operations)
 
 """
     reset_graph!(graph::DAG)

--- a/src/graph/mute.jl
+++ b/src/graph/mute.jl
@@ -56,7 +56,7 @@ function _insert_node!(graph::DAG, node::Node; track=true, invalidate_cache=true
     if (!invalidate_cache)
         return node
     end
-    push!(graph.dirtyNodes, node)
+    push!(graph.dirty_nodes, node)
 
     return node
 end
@@ -110,8 +110,8 @@ function _insert_edge!(
     invalidate_operation_caches!(graph, node1)
     invalidate_operation_caches!(graph, node2)
 
-    push!(graph.dirtyNodes, node1)
-    push!(graph.dirtyNodes, node2)
+    push!(graph.dirty_nodes, node1)
+    push!(graph.dirty_nodes, node2)
 
     return nothing
 end
@@ -145,7 +145,7 @@ function _remove_node!(graph::DAG, node::Node; track=true, invalidate_cache=true
     end
 
     invalidate_operation_caches!(graph, node)
-    delete!(graph.dirtyNodes, node)
+    delete!(graph.dirty_nodes, node)
 
     return nothing
 end
@@ -207,10 +207,10 @@ function _remove_edge!(
     invalidate_operation_caches!(graph, node1)
     invalidate_operation_caches!(graph, node2)
     if (node1 in graph)
-        push!(graph.dirtyNodes, node1)
+        push!(graph.dirty_nodes, node1)
     end
     if (node2 in graph)
-        push!(graph.dirtyNodes, node2)
+        push!(graph.dirty_nodes, node2)
     end
 
     return removed_node_index
@@ -235,7 +235,7 @@ Invalidate the operation caches for a given [`NodeReduction`](@ref).
 This deletes the operation from the graph's possible operations and from the involved nodes' own operation caches.
 """
 function invalidate_caches!(graph::DAG, operation::NodeReduction)
-    delete!(graph.possibleOperations, operation)
+    delete!(graph.possible_operations, operation)
 
     for node in operation.input
         node.nodeReduction = missing
@@ -252,7 +252,7 @@ Invalidate the operation caches for a given [`NodeSplit`](@ref).
 This deletes the operation from the graph's possible operations and from the involved nodes' own operation caches.
 """
 function invalidate_caches!(graph::DAG, operation::NodeSplit)
-    delete!(graph.possibleOperations, operation)
+    delete!(graph.possible_operations, operation)
 
     # delete the operation from all caches of nodes involved in the operation
     # for node split there is only one node

--- a/src/graph/mute.jl
+++ b/src/graph/mute.jl
@@ -238,7 +238,7 @@ function invalidate_caches!(graph::DAG, operation::NodeReduction)
     delete!(graph.possible_operations, operation)
 
     for node in operation.input
-        node.nodeReduction = missing
+        node.node_reduction = missing
     end
 
     return nothing
@@ -256,7 +256,7 @@ function invalidate_caches!(graph::DAG, operation::NodeSplit)
 
     # delete the operation from all caches of nodes involved in the operation
     # for node split there is only one node
-    operation.input.nodeSplit = missing
+    operation.input.node_split = missing
 
     return nothing
 end
@@ -267,11 +267,11 @@ end
 Invalidate the operation caches of the given node through calls to the respective [`invalidate_caches!`](@ref) functions.
 """
 function invalidate_operation_caches!(graph::DAG, node::ComputeTaskNode)
-    if !ismissing(node.nodeReduction)
-        invalidate_caches!(graph, node.nodeReduction)
+    if !ismissing(node.node_reduction)
+        invalidate_caches!(graph, node.node_reduction)
     end
-    if !ismissing(node.nodeSplit)
-        invalidate_caches!(graph, node.nodeSplit)
+    if !ismissing(node.node_split)
+        invalidate_caches!(graph, node.node_split)
     end
     return nothing
 end
@@ -282,11 +282,11 @@ end
 Invalidate the operation caches of the given node through calls to the respective [`invalidate_caches!`](@ref) functions.
 """
 function invalidate_operation_caches!(graph::DAG, node::DataTaskNode)
-    if !ismissing(node.nodeReduction)
-        invalidate_caches!(graph, node.nodeReduction)
+    if !ismissing(node.node_reduction)
+        invalidate_caches!(graph, node.node_reduction)
     end
-    if !ismissing(node.nodeSplit)
-        invalidate_caches!(graph, node.nodeSplit)
+    if !ismissing(node.node_split)
+        invalidate_caches!(graph, node.node_split)
     end
     return nothing
 end

--- a/src/graph/print.jl
+++ b/src/graph/print.jl
@@ -28,14 +28,14 @@ function Base.show(io::IO, graph::DAG)
     print(io, "  Nodes: ")
 
     nodeDict = Dict{Type,Int64}()
-    noEdges = 0
+    number_of_edges = 0
     for node in graph.nodes
         if haskey(nodeDict, typeof(task(node)))
             nodeDict[typeof(task(node))] = nodeDict[typeof(task(node))] + 1
         else
             nodeDict[typeof(task(node))] = 1
         end
-        noEdges += length(parents(node))
+        number_of_edges += length(parents(node))
     end
 
     if length(graph.nodes) <= 20
@@ -58,9 +58,9 @@ function Base.show(io::IO, graph::DAG)
         end
     end
     println(io)
-    println(io, "  Edges: ", noEdges)
+    println(io, "  Edges: ", number_of_edges)
     properties = get_properties(graph)
-    println(io, "  Total Compute Effort: ", properties.computeEffort)
+    println(io, "  Total Compute Effort: ", properties.compute_effort)
     println(io, "  Total Data Transfer: ", properties.data)
-    return println(io, "  Total Compute Intensity: ", properties.computeIntensity)
+    return println(io, "  Total Compute Intensity: ", properties.compute_intensity)
 end

--- a/src/graph/properties.jl
+++ b/src/graph/properties.jl
@@ -8,7 +8,7 @@ function get_properties(graph::DAG)
     apply_all!(graph)
 
     # TODO: tests stop working without the if condition, which means there is probably a bug in the lazy evaluation and in the tests
-    if (graph.properties.computeEffort <= 0.0)
+    if (graph.properties.compute_effort <= 0.0)
         graph.properties = GraphProperties(graph)
     end
 
@@ -51,5 +51,5 @@ end
 Return the number of operations applied to the graph.
 """
 function operation_stack_length(graph::DAG)
-    return length(graph.appliedOperations) + length(graph.operationsToApply)
+    return length(graph.applied_operations) + length(graph.operations_to_apply)
 end

--- a/src/graph/type.jl
+++ b/src/graph/type.jl
@@ -7,8 +7,8 @@ A struct storing all possible operations on a [`DAG`](@ref).
 To get the [`PossibleOperations`](@ref) on a [`DAG`](@ref), use [`get_operations`](@ref).
 """
 mutable struct PossibleOperations
-    nodeReductions::Set{NodeReduction}
-    nodeSplits::Set{NodeSplit}
+    node_reductions::Set{NodeReduction}
+    node_splits::Set{NodeSplit}
 end
 
 """ 
@@ -24,16 +24,16 @@ mutable struct DAG
     nodes::Set{Union{DataTaskNode,ComputeTaskNode}}
 
     # The operations currently applied to the set of nodes
-    appliedOperations::Stack{AppliedOperation}
+    applied_operations::Stack{AppliedOperation}
 
     # The operations not currently applied but part of the current state of the DAG
-    operationsToApply::Deque{Operation}
+    operations_to_apply::Deque{Operation}
 
     # The possible operations at the current state of the DAG
-    possibleOperations::PossibleOperations
+    possible_operations::PossibleOperations
 
     # The set of nodes whose possible operations need to be reevaluated
-    dirtyNodes::Set{Union{DataTaskNode,ComputeTaskNode}}
+    dirty_nodes::Set{Union{DataTaskNode,ComputeTaskNode}}
 
     # "snapshot" system: keep track of added/removed nodes/edges since last snapshot
     # these are muted in insert_node! etc.

--- a/src/graph/validate.jl
+++ b/src/graph/validate.jl
@@ -30,18 +30,18 @@ function is_valid(graph::DAG)
         @assert is_valid(graph, node)
     end
 
-    for op in graph.operationsToApply
+    for op in graph.operations_to_apply
         @assert is_valid(graph, op)
     end
 
-    for nr in graph.possibleOperations.nodeReductions
+    for nr in graph.possible_operations.node_reductions
         @assert is_valid(graph, nr)
     end
-    for ns in graph.possibleOperations.nodeSplits
+    for ns in graph.possible_operations.node_splits
         @assert is_valid(graph, ns)
     end
 
-    for node in graph.dirtyNodes
+    for node in graph.dirty_nodes
         @assert node in graph "Dirty Node is not part of the graph!"
         @assert ismissing(node.nodeReduction) "Dirty Node has a NodeReduction!"
         @assert ismissing(node.nodeSplit) "Dirty Node has a NodeSplit!"

--- a/src/graph/validate.jl
+++ b/src/graph/validate.jl
@@ -43,8 +43,8 @@ function is_valid(graph::DAG)
 
     for node in graph.dirty_nodes
         @assert node in graph "Dirty Node is not part of the graph!"
-        @assert ismissing(node.nodeReduction) "Dirty Node has a NodeReduction!"
-        @assert ismissing(node.nodeSplit) "Dirty Node has a NodeSplit!"
+        @assert ismissing(node.node_reduction) "Dirty Node has a NodeReduction!"
+        @assert ismissing(node.node_split) "Dirty Node has a NodeSplit!"
     end
 
     @assert is_connected(graph) "Graph is not connected!"

--- a/src/models/interface.jl
+++ b/src/models/interface.jl
@@ -1,44 +1,26 @@
-
 """
-    AbstractModel
+    input_type(problem_instance)
 
-Base type for all models. From this, [`AbstractProblemInstance`](@ref)s can be constructed.
+Return the input type for a specific `problem_instance`. This can be a specific type or a supertype for which all child types are expected to be implemented.
 
-See also: [`problem_instance`](@ref)
-"""
-abstract type AbstractModel end
-
-"""
-    problem_instance(::AbstractModel, ::Vararg)
-
-Interface function that must be implemented for any implementation of [`AbstractModel`](@ref). This function should return a specific [`AbstractProblemInstance`](@ref) given some parameters.
-"""
-function problem_instance end
-
-"""
-    AbstractProblemInstance
-
-Base type for problem instances. An object of this type of a corresponding [`AbstractModel`](@ref) should uniquely identify a problem instance of that model.
-"""
-abstract type AbstractProblemInstance end
-
-"""
-    input_type(problem::AbstractProblemInstance)
-
-Return the input type for a specific [`AbstractProblemInstance`](@ref). This can be a specific type or a supertype for which all child types are expected to work.
+For more details on the `problem_instance`, please refer to the documentation.
 """
 function input_type end
 
 """
-    graph(::AbstractProblemInstance)
+    graph(problem_instance)
 
-Generate the [`DAG`](@ref) for the given [`AbstractProblemInstance`](@ref). Every entry node (see [`get_entry_nodes`](@ref)) to the graph must have a name set. Implement [`input_expr`](@ref) to return a valid expression for each of those names.
+Generate the [`DAG`](@ref) for the given `problem_instance`. Every entry node (see [`get_entry_nodes`](@ref)) to the graph must have a name set. Implement [`input_expr`](@ref) to return a valid expression for each of those names.
+
+For more details on the `problem_instance`, please refer to the documentation.
 """
 function graph end
 
 """
-    input_expr(instance::AbstractProblemInstance, name::String, input_symbol::Symbol)
+    input_expr(problem_instance, name::String, input_symbol::Symbol)
 
-For the given [`AbstractProblemInstance`](@ref), the entry node name, and the symbol of the problem input (where a variable of type `input_type(...)` will exist), return an `Expr` that gets that specific input value from the input symbol.
+For the given `problem_instance`, the entry node name, and the symbol of the problem input (where a variable of type `input_type(...)` will exist), return an `Expr` that gets that specific input value from the input symbol.
+
+For more details on the `problem_instance`, please refer to the documentation.
 """
 function input_expr end

--- a/src/node/type.jl
+++ b/src/node/type.jl
@@ -27,8 +27,8 @@ Any node that transfers data and does no computation.
 `.parents`:         A vector of the node's parents (i.e. nodes that depend on this one).\\
 `.children`:        A vector of tuples of the node's children (i.e. nodes that this one depends on) and their indices, indicating their order in the resulting function call passed to the task.\\
 `.id`:              The node's id. Improves the speed of comparisons and is used as a unique identifier.\\
-`.nodeReduction`:   Either this node's [`NodeReduction`](@ref) or `missing`, if none. There can only be at most one.\\
-`.nodeSplit`:       Either this node's [`NodeSplit`](@ref) or `missing`, if none. There can only be at most one.\\
+`.node_reduction`:  Either this node's [`NodeReduction`](@ref) or `missing`, if none. There can only be at most one.\\
+`.node_split`:      Either this node's [`NodeSplit`](@ref) or `missing`, if none. There can only be at most one.\\
 `.name`:            The name of this node for entry nodes into the graph ([`is_entry_node`](@ref)) to reliably assign the inputs to the correct nodes when executing.\\
 """
 mutable struct DataTaskNode{TaskType<:AbstractDataTask} <: Node
@@ -44,10 +44,10 @@ mutable struct DataTaskNode{TaskType<:AbstractDataTask} <: Node
 
     # the NodeReduction involving this node, if it exists
     # Can't use the NodeReduction type here because it's not yet defined
-    nodeReduction::Union{Operation,Missing}
+    node_reduction::Union{Operation,Missing}
 
     # the NodeSplit involving this node, if it exists
-    nodeSplit::Union{Operation,Missing}
+    node_split::Union{Operation,Missing}
 
     # for input nodes we need a name for the node to distinguish between them
     name::String
@@ -63,8 +63,8 @@ Any node that computes a result from inputs using an [`AbstractComputeTask`](@re
 `.parents`:         A vector of the node's parents (i.e. nodes that depend on this one).\\
 `.children`:        A vector of tuples with the node's children (i.e. nodes that this one depends on) and their index, used to order the arguments for the [`AbstractComputeTask`](@ref).\\
 `.id`:              The node's id. Improves the speed of comparisons and is used as a unique identifier.\\
-`.nodeReduction`:   Either this node's [`NodeReduction`](@ref) or `missing`, if none. There can only be at most one.\\
-`.nodeSplit`:       Either this node's [`NodeSplit`](@ref) or `missing`, if none. There can only be at most one.\\
+`.node_reduction`:  Either this node's [`NodeReduction`](@ref) or `missing`, if none. There can only be at most one.\\
+`.node_split`:      Either this node's [`NodeSplit`](@ref) or `missing`, if none. There can only be at most one.\\
 `.device`:          The Device this node has been scheduled on by a [`Scheduler`](@ref).
 """
 mutable struct ComputeTaskNode{TaskType<:AbstractComputeTask} <: Node
@@ -73,8 +73,8 @@ mutable struct ComputeTaskNode{TaskType<:AbstractComputeTask} <: Node
     children::Vector{Tuple{Node,Int}}
     id::Base.UUID
 
-    nodeReduction::Union{Operation,Missing}
-    nodeSplit::Union{Operation,Missing}
+    node_reduction::Union{Operation,Missing}
+    node_split::Union{Operation,Missing}
 
     # the device this node is assigned to execute on
     device::Union{AbstractDevice,Missing}

--- a/src/node/validate.jl
+++ b/src/node/validate.jl
@@ -22,11 +22,11 @@ function is_valid_node(graph::DAG, node::Node)
         @assert node in child.parents "Node is not a parent of its child!"
     end
 
-    #=if !ismissing(node.nodeReduction)
-        @assert is_valid(graph, node.nodeReduction)
+    #=if !ismissing(node.node_reduction)
+        @assert is_valid(graph, node.node_reduction)
     end
-    if !ismissing(node.nodeSplit)
-        @assert is_valid(graph, node.nodeSplit)
+    if !ismissing(node.node_split)
+        @assert is_valid(graph, node.node_split)
     end=#
 
     return true

--- a/src/operation/apply.jl
+++ b/src/operation/apply.jl
@@ -182,13 +182,14 @@ function node_split!(
     get_snapshot_diff(graph)
 
     n1_parents = copy(parents(n1))
+    local parent_indices = Dict()
     n1_children = copy(children(n1))
 
     for parent in n1_parents
-        _remove_edge!(graph, n1, parent)
+        parent_indices[parent] = _remove_edge!(graph, n1, parent)
     end
     for (child, index) in n1_children
-        _remove_edge!(graph, child, n1)
+        @assert index == _remove_edge!(graph, child, n1)
     end
     _remove_node!(graph, n1)
 
@@ -196,10 +197,10 @@ function node_split!(
         n_copy = copy(n1)
 
         _insert_node!(graph, n_copy)
-        _insert_edge!(graph, n_copy, parent)
+        _insert_edge!(graph, n_copy, parent, parent_indices[parent])
 
         for (child, index) in n1_children
-            _insert_edge!(graph, child, n_copy)
+            _insert_edge!(graph, child, n_copy, index)
         end
     end
 

--- a/src/operation/apply.jl
+++ b/src/operation/apply.jl
@@ -4,15 +4,15 @@
 Apply all unapplied operations in the DAG. Is automatically called in all functions that require the latest state of the [`DAG`](@ref).
 """
 function apply_all!(graph::DAG)
-    while !isempty(graph.operationsToApply)
+    while !isempty(graph.operations_to_apply)
         # get next operation to apply from front of the deque
-        op = popfirst!(graph.operationsToApply)
+        op = popfirst!(graph.operations_to_apply)
 
         # apply it
         appliedOp = apply_operation!(graph, op)
 
-        # push to the end of the appliedOperations deque
-        push!(graph.appliedOperations, appliedOp)
+        # push to the end of the applied_operations deque
+        push!(graph.applied_operations, appliedOp)
     end
     return nothing
 end

--- a/src/operation/clean.jl
+++ b/src/operation/clean.jl
@@ -7,7 +7,7 @@ Find node reductions involving the given node. The function pushes the found [`N
 """
 function find_reductions!(graph::DAG, node::Node)
     # there can only be one reduction per node, avoid adding duplicates
-    if !ismissing(node.nodeReduction)
+    if !ismissing(node.node_reduction)
         return nothing
     end
 
@@ -32,12 +32,12 @@ function find_reductions!(graph::DAG, node::Node)
         nr = NodeReduction(reductionVector)
         push!(graph.possible_operations.node_reductions, nr)
         for node in reductionVector
-            if !ismissing(node.nodeReduction)
+            if !ismissing(node.node_reduction)
                 # it can happen that the dirty node becomes part of an existing NodeReduction and overrides those ones now
                 # this is only a problem insofar the existing NodeReduction has to be deleted and replaced also in the possible_operations
-                invalidate_caches!(graph, node.nodeReduction)
+                invalidate_caches!(graph, node.node_reduction)
             end
-            node.nodeReduction = nr
+            node.node_reduction = nr
         end
     end
 
@@ -50,14 +50,14 @@ end
 Find the node split of the given node. The function pushes the found [`NodeSplit`](@ref) (if any) everywhere it needs to be and returns nothing.
 """
 function find_splits!(graph::DAG, node::Node)
-    if !ismissing(node.nodeSplit)
+    if !ismissing(node.node_split)
         return nothing
     end
 
     if (can_split(node))
         ns = NodeSplit(node)
         push!(graph.possible_operations.node_splits, ns)
-        node.nodeSplit = ns
+        node.node_split = ns
     end
 
     return nothing

--- a/src/operation/clean.jl
+++ b/src/operation/clean.jl
@@ -30,11 +30,11 @@ function find_reductions!(graph::DAG, node::Node)
 
     if reductionVector !== nothing
         nr = NodeReduction(reductionVector)
-        push!(graph.possibleOperations.nodeReductions, nr)
+        push!(graph.possible_operations.node_reductions, nr)
         for node in reductionVector
             if !ismissing(node.nodeReduction)
                 # it can happen that the dirty node becomes part of an existing NodeReduction and overrides those ones now
-                # this is only a problem insofar the existing NodeReduction has to be deleted and replaced also in the possibleOperations
+                # this is only a problem insofar the existing NodeReduction has to be deleted and replaced also in the possible_operations
                 invalidate_caches!(graph, node.nodeReduction)
             end
             node.nodeReduction = nr
@@ -56,7 +56,7 @@ function find_splits!(graph::DAG, node::Node)
 
     if (can_split(node))
         ns = NodeSplit(node)
-        push!(graph.possibleOperations.nodeSplits, ns)
+        push!(graph.possible_operations.node_splits, ns)
         node.nodeSplit = ns
     end
 

--- a/src/operation/find.jl
+++ b/src/operation/find.jl
@@ -9,7 +9,7 @@ Insert the given node reduction into its input nodes' operation caches. This is 
 """
 function insert_operation!(nr::NodeReduction)
     for n in nr.input
-        n.nodeReduction = nr
+        n.node_reduction = nr
     end
     return nothing
 end
@@ -20,7 +20,7 @@ end
 Insert the given node split into its input node's operation cache. This is thread-safe.
 """
 function insert_operation!(ns::NodeSplit)
-    ns.input.nodeSplit = ns
+    ns.input.node_split = ns
     return nothing
 end
 
@@ -127,7 +127,7 @@ function generate_operations(graph::DAG)
         node_reductions = collect(trie)
 
         for nrVec in node_reductions
-            # parent sets are ordered and any node can only be part of one nodeReduction, so a NodeReduction is uniquely identifiable by its first element
+            # parent sets are ordered and any node can only be part of one node_reduction, so a NodeReduction is uniquely identifiable by its first element
             # this prevents duplicate node_reductions being generated
             lock(checkedNodesLock)
             if (nrVec[1] in checkedNodes)

--- a/src/operation/get.jl
+++ b/src/operation/get.jl
@@ -10,12 +10,12 @@ Return the [`PossibleOperations`](@ref) of the graph at the current state.
 function get_operations(graph::DAG)
     apply_all!(graph)
 
-    if isempty(graph.possibleOperations)
+    if isempty(graph.possible_operations)
         generate_operations(graph)
     end
 
-    clean_node!.(Ref(graph), graph.dirtyNodes)
-    empty!(graph.dirtyNodes)
+    clean_node!.(Ref(graph), graph.dirty_nodes)
+    empty!(graph.dirty_nodes)
 
-    return graph.possibleOperations
+    return graph.possible_operations
 end

--- a/src/operation/iterate.jl
+++ b/src/operation/iterate.jl
@@ -5,10 +5,10 @@ _POIteratorStateType = NamedTuple{
 }
 
 @inline function Base.iterate(
-    possibleOperations::PossibleOperations
+    possible_operations::PossibleOperations
 )::Union{Nothing,_POIteratorStateType}
     for fieldname in _POSSIBLE_OPERATIONS_FIELDS
-        iterator = iterate(getfield(possibleOperations, fieldname))
+        iterator = iterate(getfield(possible_operations, fieldname))
         if (!isnothing(iterator))
             return (result=iterator[1], state=(fieldname, iterator[2]))
         end
@@ -18,10 +18,10 @@ _POIteratorStateType = NamedTuple{
 end
 
 @inline function Base.iterate(
-    possibleOperations::PossibleOperations, state
+    possible_operations::PossibleOperations, state
 )::Union{Nothing,_POIteratorStateType}
     newStateSym = state[1]
-    newStateIt = iterate(getfield(possibleOperations, newStateSym), state[2])
+    newStateIt = iterate(getfield(possible_operations, newStateSym), state[2])
     if !isnothing(newStateIt)
         return (result=newStateIt[1], state=(newStateSym, newStateIt[2]))
     end
@@ -31,7 +31,7 @@ end
 
     while index <= length(_POSSIBLE_OPERATIONS_FIELDS)
         newStateSym = _POSSIBLE_OPERATIONS_FIELDS[index]
-        newStateIt = iterate(getfield(possibleOperations, newStateSym))
+        newStateIt = iterate(getfield(possible_operations, newStateSym))
         if !isnothing(newStateIt)
             return (result=newStateIt[1], state=(newStateSym, newStateIt[2]))
         end

--- a/src/operation/print.jl
+++ b/src/operation/print.jl
@@ -4,14 +4,14 @@
 Print a string representation of the set of possible operations to io.
 """
 function Base.show(io::IO, ops::PossibleOperations)
-    print(io, length(ops.nodeReductions))
+    print(io, length(ops.node_reductions))
     println(io, " Node Reductions: ")
-    for nr in ops.nodeReductions
+    for nr in ops.node_reductions
         println(io, "  - ", nr)
     end
-    print(io, length(ops.nodeSplits))
+    print(io, length(ops.node_splits))
     println(io, " Node Splits: ")
-    for ns in ops.nodeSplits
+    for ns in ops.node_splits
         println(io, "  - ", ns)
     end
 end

--- a/src/operation/utility.jl
+++ b/src/operation/utility.jl
@@ -4,7 +4,7 @@
 Return whether `operations` is empty, i.e. all of its fields are empty.
 """
 function Base.isempty(operations::PossibleOperations)
-    return isempty(operations.nodeReductions) && isempty(operations.nodeSplits)
+    return isempty(operations.node_reductions) && isempty(operations.node_splits)
 end
 
 """
@@ -14,8 +14,8 @@ Return a named tuple with the number of each of the operation types as a named t
 """
 function Base.length(operations::PossibleOperations)
     return (
-        nodeReductions=length(operations.nodeReductions),
-        nodeSplits=length(operations.nodeSplits),
+        node_reductions=length(operations.node_reductions),
+        node_splits=length(operations.node_splits),
     )
 end
 
@@ -25,7 +25,7 @@ end
 Delete the given node reduction from the possible operations.
 """
 function Base.delete!(operations::PossibleOperations, op::NodeReduction)
-    delete!(operations.nodeReductions, op)
+    delete!(operations.node_reductions, op)
     return operations
 end
 
@@ -35,7 +35,7 @@ end
 Delete the given node split from the possible operations.
 """
 function Base.delete!(operations::PossibleOperations, op::NodeSplit)
-    delete!(operations.nodeSplits, op)
+    delete!(operations.node_splits, op)
     return operations
 end
 

--- a/src/optimization/random_walk.jl
+++ b/src/optimization/random_walk.jl
@@ -15,7 +15,7 @@ function optimize_step!(optimizer::RandomWalkOptimizer, graph::DAG)
     operations = get_operations(graph)
 
     if sum(length(operations)) == 0 &&
-        length(graph.appliedOperations) + length(graph.operationsToApply) == 0
+        length(graph.applied_operations) + length(graph.operations_to_apply) == 0
         # in case there are zero operations possible at all on the graph
         return false
     end
@@ -29,11 +29,11 @@ function optimize_step!(optimizer::RandomWalkOptimizer, graph::DAG)
 
             # choose one of split/reduce
             option = rand(r, 1:2)
-            if option == 1 && !isempty(operations.nodeReductions)
-                push_operation!(graph, rand(r, collect(operations.nodeReductions)))
+            if option == 1 && !isempty(operations.node_reductions)
+                push_operation!(graph, rand(r, collect(operations.node_reductions)))
                 return true
-            elseif option == 2 && !isempty(operations.nodeSplits)
-                push_operation!(graph, rand(r, collect(operations.nodeSplits)))
+            elseif option == 2 && !isempty(operations.node_splits)
+                push_operation!(graph, rand(r, collect(operations.node_splits)))
                 return true
             end
         else

--- a/src/optimization/reduce.jl
+++ b/src/optimization/reduce.jl
@@ -14,14 +14,14 @@ function optimize_step!(optimizer::ReductionOptimizer, graph::DAG)
         return false
     end
 
-    push_operation!(graph, first(operations.nodeReductions))
+    push_operation!(graph, first(operations.node_reductions))
 
     return true
 end
 
 function fixpoint_reached(optimizer::ReductionOptimizer, graph::DAG)
     operations = get_operations(graph)
-    return isempty(operations.nodeReductions)
+    return isempty(operations.node_reductions)
 end
 
 function optimize_to_fixpoint!(optimizer::ReductionOptimizer, graph::DAG)

--- a/src/optimization/split.jl
+++ b/src/optimization/split.jl
@@ -14,14 +14,14 @@ function optimize_step!(optimizer::SplitOptimizer, graph::DAG)
         return false
     end
 
-    push_operation!(graph, first(operations.nodeSplits))
+    push_operation!(graph, first(operations.node_splits))
 
     return true
 end
 
 function fixpoint_reached(optimizer::SplitOptimizer, graph::DAG)
     operations = get_operations(graph)
-    return isempty(operations.nodeSplits)
+    return isempty(operations.node_splits)
 end
 
 function optimize_to_fixpoint!(optimizer::SplitOptimizer, graph::DAG)

--- a/src/properties/create.jl
+++ b/src/properties/create.jl
@@ -5,7 +5,11 @@ Create an empty [`GraphProperties`](@ref) object.
 """
 function GraphProperties()
     return (
-        data=0.0, computeEffort=0.0, computeIntensity=0.0, noNodes=0, noEdges=0
+        data=0.0,
+        compute_effort=0.0,
+        compute_intensity=0.0,
+        number_of_nodes=0,
+        number_of_edges=0,
     )::GraphProperties
 end
 
@@ -41,10 +45,10 @@ function GraphProperties(graph::DAG)
 
     return (
         data=d,
-        computeEffort=ce,
-        computeIntensity=(d == 0) ? 0.0 : ce / d,
-        noNodes=length(graph.nodes),
-        noEdges=ed,
+        compute_effort=ce,
+        compute_intensity=(d == 0) ? 0.0 : ce / d,
+        number_of_nodes=length(graph.nodes),
+        number_of_edges=ed,
     )::GraphProperties
 end
 
@@ -66,9 +70,9 @@ function GraphProperties(diff::Diff)
 
     return (
         data=d,
-        computeEffort=ce,
-        computeIntensity=(d == 0) ? 0.0 : ce / d,
-        noNodes=length(diff.addedNodes) - length(diff.removedNodes),
-        noEdges=length(diff.addedEdges) - length(diff.removedEdges),
+        compute_effort=ce,
+        compute_intensity=(d == 0) ? 0.0 : ce / d,
+        number_of_nodes=length(diff.addedNodes) - length(diff.removedNodes),
+        number_of_edges=length(diff.addedEdges) - length(diff.removedEdges),
     )::GraphProperties
 end

--- a/src/properties/type.jl
+++ b/src/properties/type.jl
@@ -3,12 +3,12 @@
 
 Representation of a [`DAG`](@ref)'s properties.
 
-# Fields:
-`.data`: The total data transfer.\\
-`.compute_effort`: The total compute effort.\\
-`.compute_intensity`: The compute intensity, will always equal `.compute_effort / .data`.\\
-`.number_of_nodes`: Number of [`Node`](@ref)s.\\
-`.number_of_edges`: Number of [`Edge`](@ref)s.
+## Fields:
+- `data::Float64`: The total data transfer.
+- `compute_effort::Float64`: The total compute effort.
+- `compute_intensity::Float64`: The compute intensity, will always equal `compute_effort / data`.
+- `number_of_nodes::Int`: Number of [`Node`](@ref)s.
+- `number_of_edges::Int`: Number of [`Edge`](@ref)s.
 """
 const GraphProperties = NamedTuple{
     (:data, :compute_effort, :compute_intensity, :number_of_nodes, :number_of_edges),

--- a/src/properties/type.jl
+++ b/src/properties/type.jl
@@ -5,12 +5,12 @@ Representation of a [`DAG`](@ref)'s properties.
 
 # Fields:
 `.data`: The total data transfer.\\
-`.computeEffort`: The total compute effort.\\
-`.computeIntensity`: The compute intensity, will always equal `.computeEffort / .data`.\\
-`.noNodes`: Number of [`Node`](@ref)s.\\
-`.noEdges`: Number of [`Edge`](@ref)s.
+`.compute_effort`: The total compute effort.\\
+`.compute_intensity`: The compute intensity, will always equal `.compute_effort / .data`.\\
+`.number_of_nodes`: Number of [`Node`](@ref)s.\\
+`.number_of_edges`: Number of [`Edge`](@ref)s.
 """
 const GraphProperties = NamedTuple{
-    (:data, :computeEffort, :computeIntensity, :noNodes, :noEdges),
+    (:data, :compute_effort, :compute_intensity, :number_of_nodes, :number_of_edges),
     Tuple{Float64,Float64,Float64,Int,Int},
 }

--- a/src/properties/utility.jl
+++ b/src/properties/utility.jl
@@ -7,14 +7,14 @@ Also take care to keep consistent compute intensity.
 function Base.:-(prop1::GraphProperties, prop2::GraphProperties)
     return (
         data=prop1.data - prop2.data,
-        computeEffort=prop1.computeEffort - prop2.computeEffort,
-        computeIntensity=if (prop1.data - prop2.data == 0)
+        compute_effort=prop1.compute_effort - prop2.compute_effort,
+        compute_intensity=if (prop1.data - prop2.data == 0)
             0.0
         else
-            (prop1.computeEffort - prop2.computeEffort) / (prop1.data - prop2.data)
+            (prop1.compute_effort - prop2.compute_effort) / (prop1.data - prop2.data)
         end,
-        noNodes=prop1.noNodes - prop2.noNodes,
-        noEdges=prop1.noEdges - prop2.noEdges,
+        number_of_nodes=prop1.number_of_nodes - prop2.number_of_nodes,
+        number_of_edges=prop1.number_of_edges - prop2.number_of_edges,
     )::GraphProperties
 end
 
@@ -27,28 +27,28 @@ Also take care to keep consistent compute intensity.
 function Base.:+(prop1::GraphProperties, prop2::GraphProperties)
     return (
         data=prop1.data + prop2.data,
-        computeEffort=prop1.computeEffort + prop2.computeEffort,
-        computeIntensity=if (prop1.data + prop2.data == 0)
+        compute_effort=prop1.compute_effort + prop2.compute_effort,
+        compute_intensity=if (prop1.data + prop2.data == 0)
             0.0
         else
-            (prop1.computeEffort + prop2.computeEffort) / (prop1.data + prop2.data)
+            (prop1.compute_effort + prop2.compute_effort) / (prop1.data + prop2.data)
         end,
-        noNodes=prop1.noNodes + prop2.noNodes,
-        noEdges=prop1.noEdges + prop2.noEdges,
+        number_of_nodes=prop1.number_of_nodes + prop2.number_of_nodes,
+        number_of_edges=prop1.number_of_edges + prop2.number_of_edges,
     )::GraphProperties
 end
 
 """
     -(prop::GraphProperties)
 
-Unary negation of the graph properties. `.computeIntensity` will not be negated because `.data` and `.computeEffort` both are.
+Unary negation of the graph properties. `.compute_intensity` will not be negated because `.data` and `.compute_effort` both are.
 """
 function Base.:-(prop::GraphProperties)
     return (
         data=-prop.data,
-        computeEffort=-prop.computeEffort,
-        computeIntensity=prop.computeIntensity,   # no negation here!
-        noNodes=-prop.noNodes,
-        noEdges=-prop.noEdges,
+        compute_effort=-prop.compute_effort,
+        compute_intensity=prop.compute_intensity,   # no negation here!
+        number_of_nodes=-prop.number_of_nodes,
+        number_of_edges=-prop.number_of_edges,
     )::GraphProperties
 end

--- a/src/scheduler/interface.jl
+++ b/src/scheduler/interface.jl
@@ -1,11 +1,3 @@
-
-"""
-    AbstractScheduler
-
-Abstract base type for scheduler implementations. The scheduler is used to assign each node to a device and create a topological ordering of tasks.
-"""
-abstract type AbstractScheduler end
-
 """
     schedule_dag(::Scheduler, ::DAG, ::Machine)
 

--- a/src/scheduler/type.jl
+++ b/src/scheduler/type.jl
@@ -5,17 +5,17 @@ Type representing a function call. Contains the function to call, argument symbo
 
 TODO: extend docs
 """
-mutable struct FunctionCall{VAL_T<:Tuple}
-    func::Function
+mutable struct FunctionCall{VAL_T<:Tuple,FUNC_T<:Union{Function,Expr}}
+    func::FUNC_T
     value_arguments::Vector{VAL_T}          # tuple of value arguments for the function call, will be prepended to the other arguments
     arguments::Vector{Vector{Symbol}}       # symbols of the inputs to the function call
     return_symbols::Vector{Vector{Symbol}}  # the return symbols
-    return_types::Vector{<:Type}              # the return type of the function call(s); there can only be one return type since we require type stability
+    return_types::Vector{<:Type}            # the return type of the function call(s); there can only be one return type since we require type stability
     device::AbstractDevice
 end
 
 function FunctionCall(
-    func::Function,
+    func::Union{Function,Expr},
     value_arguments::VAL_T,
     arguments::Vector{Symbol},
     return_symbol::Vector{Symbol},

--- a/src/scheduler/type.jl
+++ b/src/scheduler/type.jl
@@ -1,16 +1,34 @@
-using StaticArrays
-
 """
-    FunctionCall{N}
+    FunctionCall{VAL_TYPES}
 
-Type representing a function call with `N` parameters. Contains the function to call, argument symbols, the return symbol and the device to execute on.
+Type representing a function call. Contains the function to call, argument symbols, the return symbol and the device to execute on.
+
+TODO: extend docs
 """
-mutable struct FunctionCall{VectorType<:AbstractVector,N}
+mutable struct FunctionCall{VAL_T<:Tuple,N_ARG,N_RET}
     func::Function
-    # TODO: this should be a tuple
-    value_arguments::SVector{N,Any}    # value arguments for the function call, will be prepended to the other arguments
-    arguments::VectorType              # symbols of the inputs to the function call
-    return_symbol::Symbol
-    return_type::Type
+    value_arguments::Vector{VAL_T}                          # tuple of value arguments for the function call, will be prepended to the other arguments
+    arguments::Vector{NTuple{N_ARG,Symbol}}                 # symbols of the inputs to the function call
+    return_symbols::Vector{NTuple{N_RET,Symbol}}            # the return symbols
+    return_types::NTuple{N_RET,Type}                        # the return type of the function call(s); there can only be one return type since we require type stability
     device::AbstractDevice
+end
+
+function FunctionCall(
+    func::Function,
+    value_arguments::VAL_T,
+    arguments::NTuple{N_ARG,Symbol},
+    return_symbol::NTuple{N_RET,Symbol},
+    return_types::NTuple{N_RET,Type},
+    device::AbstractDevice,
+) where {VAL_T<:Tuple,N_ARG,N_RET}
+    # convenience constructor for function calls that do not use vectorization, which is most of the use cases
+    return FunctionCall(
+        func, [value_arguments], [arguments], [return_symbol], return_types, device
+    )
+end
+
+function Base.length(fc::FunctionCall)
+    @assert length(fc.value_arguments) == length(fc.arguments) == length(fc.return_symbols) "function call length is undefined, got $(length(fc.value_arguments)) tuples of value arguments, $(length(fc.arguments)) tuples of arguments, and $(length(return_symbols)) return symbols"
+    return length(fc.value_arguments)
 end

--- a/src/scheduler/type.jl
+++ b/src/scheduler/type.jl
@@ -5,24 +5,25 @@ Type representing a function call. Contains the function to call, argument symbo
 
 TODO: extend docs
 """
-mutable struct FunctionCall{VAL_T<:Tuple,N_ARG,N_RET}
+mutable struct FunctionCall{VAL_T<:Tuple}
     func::Function
-    value_arguments::Vector{VAL_T}                          # tuple of value arguments for the function call, will be prepended to the other arguments
-    arguments::Vector{NTuple{N_ARG,Symbol}}                 # symbols of the inputs to the function call
-    return_symbols::Vector{NTuple{N_RET,Symbol}}            # the return symbols
-    return_types::NTuple{N_RET,Type}                        # the return type of the function call(s); there can only be one return type since we require type stability
+    value_arguments::Vector{VAL_T}          # tuple of value arguments for the function call, will be prepended to the other arguments
+    arguments::Vector{Vector{Symbol}}       # symbols of the inputs to the function call
+    return_symbols::Vector{Vector{Symbol}}  # the return symbols
+    return_types::Vector{<:Type}              # the return type of the function call(s); there can only be one return type since we require type stability
     device::AbstractDevice
 end
 
 function FunctionCall(
     func::Function,
     value_arguments::VAL_T,
-    arguments::NTuple{N_ARG,Symbol},
-    return_symbol::NTuple{N_RET,Symbol},
-    return_types::NTuple{N_RET,Type},
+    arguments::Vector{Symbol},
+    return_symbol::Vector{Symbol},
+    return_types::Vector{<:Type},
     device::AbstractDevice,
-) where {VAL_T<:Tuple,N_ARG,N_RET}
+) where {VAL_T<:Tuple}
     # convenience constructor for function calls that do not use vectorization, which is most of the use cases
+    @assert length(return_types) == 0 || length(return_types) == length(return_symbol) "number of return types $(length(return_types)) does not match the number of return symbols $(length(return_symbol))"
     return FunctionCall(
         func, [value_arguments], [arguments], [return_symbol], return_types, device
     )

--- a/src/scheduler/type.jl
+++ b/src/scheduler/type.jl
@@ -1,35 +1,6 @@
 """
-    FunctionCall{VAL_TYPES}
+    AbstractScheduler
 
-Type representing a function call. Contains the function to call, argument symbols, the return symbol and the device to execute on.
-
-TODO: extend docs
+Abstract base type for scheduler implementations. The scheduler is used to assign each node to a device and create a topological ordering of tasks.
 """
-mutable struct FunctionCall{VAL_T<:Tuple,FUNC_T<:Union{Function,Expr}}
-    func::FUNC_T
-    value_arguments::Vector{VAL_T}          # tuple of value arguments for the function call, will be prepended to the other arguments
-    arguments::Vector{Vector{Symbol}}       # symbols of the inputs to the function call
-    return_symbols::Vector{Vector{Symbol}}  # the return symbols
-    return_types::Vector{<:Type}            # the return type of the function call(s); there can only be one return type since we require type stability
-    device::AbstractDevice
-end
-
-function FunctionCall(
-    func::Union{Function,Expr},
-    value_arguments::VAL_T,
-    arguments::Vector{Symbol},
-    return_symbol::Vector{Symbol},
-    return_types::Vector{<:Type},
-    device::AbstractDevice,
-) where {VAL_T<:Tuple}
-    # convenience constructor for function calls that do not use vectorization, which is most of the use cases
-    @assert length(return_types) == 0 || length(return_types) == length(return_symbol) "number of return types $(length(return_types)) does not match the number of return symbols $(length(return_symbol))"
-    return FunctionCall(
-        func, [value_arguments], [arguments], [return_symbol], return_types, device
-    )
-end
-
-function Base.length(fc::FunctionCall)
-    @assert length(fc.value_arguments) == length(fc.arguments) == length(fc.return_symbols) "function call length is undefined, got $(length(fc.value_arguments)) tuples of value arguments, $(length(fc.arguments)) tuples of arguments, and $(length(return_symbols)) return symbols"
-    return length(fc.value_arguments)
-end
+abstract type AbstractScheduler end

--- a/src/task/compute.jl
+++ b/src/task/compute.jl
@@ -63,8 +63,8 @@ function _argument_types(known_res_types::Dict{Symbol,Type}, fc::FunctionCall)
 end
 
 function result_types(
-    fc::FunctionCall{VAL_T}, known_res_types::Dict{Symbol,Type}
-) where {VAL_T}
+    fc::FunctionCall{VAL_T,F_T}, known_res_types::Dict{Symbol,Type}
+) where {VAL_T,F_T<:Function}
     arg_types = (_value_argument_types(fc)..., _argument_types(known_res_types, fc)...)
     types = Base.return_types(fc.func, arg_types)
 
@@ -94,4 +94,12 @@ function result_types(
         )
     end
     return [types[1].parameters...]
+end
+
+function result_types(
+    fc::FunctionCall{VAL_T,Expr}, known_res_types::Dict{Symbol,Type}
+) where {VAL_T}
+    # assume that the return type is already set
+    @assert length(fc.return_types) == 1
+    return [fc.return_types[1]]
 end

--- a/src/task/compute.jl
+++ b/src/task/compute.jl
@@ -88,7 +88,7 @@ end
 function result_types(
     fc::FunctionCall{VAL_T,N_ARG,N_RET}, known_res_types::Dict{Symbol,Type}
 ) where {VAL_T,N_ARG,N_RET}
-    arg_types = (_value_argument_types(fc)..., _argument_types(fc)...)
+    arg_types = (_value_argument_types(fc)..., _argument_types(known_res_types, fc)...)
     types = Base.return_types(fc.func, arg_types)
 
     if length(types) > 1

--- a/src/task/compute.jl
+++ b/src/task/compute.jl
@@ -2,16 +2,17 @@ using StaticArrays
 
 """
     get_function_call(n::Node)
-    get_function_call(t::AbstractTask, device::AbstractDevice, in_symbols::AbstractVector, out_symbol::Symbol)
+    get_function_call(t::AbstractTask, device::AbstractDevice, in_symbols::NTuple{}, out_symbol::Symbol)
 
-For a node or a task together with necessary information, return a vector of [`FunctionCall`](@ref)s for the computation of the node or task.
-
-For ordinary compute or data tasks the vector will contain exactly one element.
+For a node or a task together with necessary information, a [`FunctionCall`](@ref)s for the computation of the node or task.
 """
 function get_function_call(
-    t::CompTask, device::AbstractDevice, in_symbols::AbstractVector, out_symbol::Symbol
-) where {CompTask<:AbstractComputeTask}
-    return [FunctionCall(compute, SVector{1,Any}(t), in_symbols, out_symbol, Any, device)]
+    t::AbstractComputeTask,
+    device::AbstractDevice,
+    in_symbols::NTuple{N,Symbol},
+    out_symbol::Symbol,
+) where {N}
+    return FunctionCall(compute, (t,), in_symbols, (out_symbol,), (Any,), device)
 end
 
 function get_function_call(node::ComputeTaskNode)
@@ -21,74 +22,93 @@ function get_function_call(node::ComputeTaskNode)
     # make sure the node is sorted so the arguments keep their order
     sort_node!(node)
 
-    if (length(node.children) <= 800)
-        #only use an SVector when there are few children
-        return get_function_call(
-            node.task,
-            node.device,
-            SVector{length(node.children),Symbol}(
-                Symbol.(to_var_name.(getfield.(getindex.(children(node), 1), :id)))...
-            ),
-            Symbol(to_var_name(node.id)),
-        )
-    else
-        return get_function_call(
-            node.task,
-            node.device,
-            Symbol.(to_var_name.(getfield.(getindex.(children(node), 1), :id))),
-            Symbol(to_var_name(node.id)),
-        )
-    end
+    return get_function_call(
+        node.task,
+        node.device,
+        (Symbol.(to_var_name.(getfield.(getindex.(children(node), 1), :id)))...,),
+        Symbol(to_var_name(node.id)),
+    )
 end
 
 function get_function_call(node::DataTaskNode)
     @assert length(children(node)) == 1 "trying to call get_function_call on a data task node that has $(length(node.children)) children instead of 1\nchildren: $(node.children)"
 
     # TODO: dispatch to device implementations generating the copy commands
-    return [
-        FunctionCall(
-            unpack_identity,
-            SVector{0,Any}(),
-            SVector{1,Symbol}(Symbol(to_var_name(first(children(node))[1].id))),
-            Symbol(to_var_name(node.id)),
-            Any,
-            first(children(node))[1].device,
-        ),
-    ]
+    return FunctionCall(
+        identity,
+        (),
+        (Symbol(to_var_name(first(children(node))[1].id)),),
+        (Symbol(to_var_name(node.id)),),
+        (Any,),
+        first(children(node))[1].device,
+    )
 end
 
 function get_init_function_call(node::DataTaskNode, device::AbstractDevice)
     @assert isempty(children(node)) "trying to call get_init_function_call on a data task node that is not an entry node."
 
     return FunctionCall(
-        unpack_identity,
-        SVector{0,Any}(),
-        SVector{1,Symbol}(Symbol("$(to_var_name(node.id))_in")),
-        Symbol(to_var_name(node.id)),
-        Any,
+        identity,
+        (),
+        (Symbol("$(to_var_name(node.id))_in"),),
+        (Symbol(to_var_name(node.id)),),
+        (Any,),
         device,
     )
 end
 
-function result_type(fc::FunctionCall, known_res_types::Dict{Symbol,Type})
-    argument_types = (
-        typeof.(fc.value_arguments)..., getindex.(Ref(known_res_types), fc.arguments)...
-    )
-    types = Base.return_types(fc.func, argument_types)
+_value_argument_types(fc::FunctionCall) = typeof.(fc.value_arguments[1])
+function _argument_types(known_res_types::Dict{Symbol,Type}, fc::FunctionCall)
+    return getindex.(Ref(known_res_types), fc.arguments[1])
+end
+
+function result_types(
+    fc::FunctionCall{VAL_T,N_ARG,1}, known_res_types::Dict{Symbol,Type}
+) where {VAL_T,N_ARG}
+    arg_types = (_value_argument_types(fc)..., _argument_types(known_res_types, fc)...)
+    types = Base.return_types(fc.func, arg_types)
 
     if length(types) > 1
         throw(
-            "failure during type inference: function call $fc with argument types $(argument_types) is type unstable, possible return types: $types",
+            "failure during type inference: function call $fc with argument types $(arg_types) is type unstable, possible return types: $types",
         )
     end
     if isempty(types)
         throw(
-            "failure during type inference: function call $fc with argument types $(argument_types) has no return types, this is likely because no method matches the arguments",
+            "failure during type inference: function call $fc with argument types $(arg_types) has no return types, this is likely because no method matches the arguments",
         )
     end
     if types[1] == Any
-        @warn "inferred return type 'Any' in task $fc with argument types $(argument_types)"
+        @warn "inferred return type 'Any' in task $fc with argument types $(arg_types)"
     end
 
-    return types[1]
+    return (types[1],)
+end
+
+function result_types(
+    fc::FunctionCall{VAL_T,N_ARG,N_RET}, known_res_types::Dict{Symbol,Type}
+) where {VAL_T,N_ARG,N_RET}
+    arg_types = (_value_argument_types(fc)..., _argument_types(fc)...)
+    types = Base.return_types(fc.func, arg_types)
+
+    if length(types) > 1
+        throw(
+            "failure during type inference: function call $(fc.func) with argument types $(arg_types) is type unstable, possible return types: $types",
+        )
+    end
+    if isempty(types)
+        throw(
+            "failure during type inference: function call $(fc.func) with argument types $(arg_types) has no return types, this is likely because no method matches the arguments",
+        )
+    end
+    if types[1] == Any
+        @warn "inferred return type 'Any' in task $fc with argument types $(arg_types)"
+    end
+    if !(types[1] isa Tuple) || length(types[1].parameters) != N_RET
+        throw(
+            "failure durng type inference: function call $(fc.func) was expected to return a Tuple with $N_RET elements, but returns $(types[1])",
+        )
+    end
+
+    return (types[1].parameters...,)
 end

--- a/src/trie.jl
+++ b/src/trie.jl
@@ -46,24 +46,7 @@ Insert the given node into the trie. The depth is used to iterate through the tr
 """
 function insert_helper!(
     trie::NodeIdTrie{NodeType}, node::NodeType, depth::Int
-) where {TaskType<:AbstractDataTask,NodeType<:DataTaskNode{TaskType}}
-    if (length(children(node)) == depth)
-        push!(trie.value, node)
-        return nothing
-    end
-
-    depth = depth + 1
-    id = node.children[depth][1].id
-
-    if (!haskey(trie.children, id))
-        trie.children[id] = NodeIdTrie{NodeType}()
-    end
-    return insert_helper!(trie.children[id], node, depth)
-end
-# TODO: Remove this workaround once https://github.com/JuliaLang/julia/issues/54404 is fixed in julia 1.10+
-function insert_helper!(
-    trie::NodeIdTrie{NodeType}, node::NodeType, depth::Int
-) where {TaskType<:AbstractComputeTask,NodeType<:ComputeTaskNode{TaskType}}
+) where {NodeType<:Node}
     if (length(children(node)) == depth)
         push!(trie.value, node)
         return nothing
@@ -83,18 +66,7 @@ end
 
 Insert the given node into the trie. It's sorted by its type in the first layer, then by its children in the following layers.
 """
-function Base.insert!(
-    trie::NodeTrie, node::NodeType
-) where {TaskType<:AbstractDataTask,NodeType<:DataTaskNode{TaskType}}
-    if (!haskey(trie.children, NodeType))
-        trie.children[NodeType] = NodeIdTrie{NodeType}()
-    end
-    return insert_helper!(trie.children[NodeType], node, 0)
-end
-# TODO: Remove this workaround once https://github.com/JuliaLang/julia/issues/54404 is fixed in julia 1.10+
-function Base.insert!(
-    trie::NodeTrie, node::NodeType
-) where {TaskType<:AbstractComputeTask,NodeType<:ComputeTaskNode{TaskType}}
+function Base.insert!(trie::NodeTrie, node::NodeType) where {NodeType<:Node}
     if (!haskey(trie.children, NodeType))
         trie.children[NodeType] = NodeIdTrie{NodeType}()
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -6,14 +6,6 @@ Function with no arguments, returns nothing, does nothing. Useful for noop [`Fun
 @inline noop() = nothing
 
 """
-    unpack_identity(x::SVector)
-
-Function taking an `SVector`, returning it unpacked.
-"""
-@inline unpack_identity(x::SVector{1,<:Any}) = x[1]
-@inline unpack_identity(x) = x
-
-"""
     bytes_to_human_readable(bytes)
 
 Return a human readable string representation of the given number.
@@ -118,17 +110,6 @@ end
 
 Return the given vector as single String without quotation marks or brackets.
 """
-function unroll_symbol_vector(vec::Vector)
-    result = ""
-    for s in vec
-        if (result != "")
-            result *= ", "
-        end
-        result *= "$s"
-    end
-    return result
-end
-
-function unroll_symbol_vector(vec::SVector)
-    return unroll_symbol_vector(Vector(vec))
+function unroll_symbol_vector(vec::VEC) where {VEC<:Union{AbstractVector,Tuple}}
+    return Expr(:tuple, vec...)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -72,18 +72,18 @@ function mem(graph::DAG)
         size += mem(n)
     end
 
-    size += sizeof(graph.appliedOperations)
-    size += sizeof(graph.operationsToApply)
+    size += sizeof(graph.applied_operations)
+    size += sizeof(graph.operations_to_apply)
 
-    size += sizeof(graph.possibleOperations)
-    for op in graph.possibleOperations.nodeReductions
+    size += sizeof(graph.possible_operations)
+    for op in graph.possible_operations.node_reductions
         size += mem(op)
     end
-    for op in graph.possibleOperations.nodeSplits
+    for op in graph.possible_operations.node_splits
         size += mem(op)
     end
 
-    size += Base.summarysize(graph.dirtyNodes; exclude=Union{Node})
+    size += Base.summarysize(graph.dirty_nodes; exclude=Union{Node})
     return size += sizeof(diff)
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -113,3 +113,7 @@ Return the given vector as single String without quotation marks or brackets.
 function unroll_symbol_vector(vec::VEC) where {VEC<:Union{AbstractVector,Tuple}}
     return Expr(:tuple, vec...)
 end
+
+@inline function _call(f, args::Vararg)
+    return f(args...)
+end

--- a/test/strassen_test.jl
+++ b/test/strassen_test.jl
@@ -53,12 +53,10 @@ EDGE_NUMBERS = (3, 96, 747, 5304) #, 37203
         @test isapprox(f(input), input[1] * input[2])
     end
 
-    #= TODO: reenable when closures work again
     @testset "Execution with closures" begin
         f_closures = get_compute_function(g, mm, cpu_st(), @__MODULE__; closures_size=100)
 
         @test Base.return_types(f_closures, (typeof(input),))[1] == typeof(input[1])
         @test isapprox(f_closures(input), input[1] * input[2])
     end
-    =#
 end

--- a/test/strassen_test.jl
+++ b/test/strassen_test.jl
@@ -53,10 +53,12 @@ EDGE_NUMBERS = (3, 96, 747, 5304) #, 37203
         @test isapprox(f(input), input[1] * input[2])
     end
 
+    #= TODO: reenable when closures work again
     @testset "Execution with closures" begin
         f_closures = get_compute_function(g, mm, cpu_st(), @__MODULE__; closures_size=100)
 
         @test Base.return_types(f_closures, (typeof(input),))[1] == typeof(input[1])
         @test isapprox(f_closures(input), input[1] * input[2])
     end
+    =#
 end

--- a/test/strassen_test.jl
+++ b/test/strassen_test.jl
@@ -38,8 +38,8 @@ EDGE_NUMBERS = (3, 96, 747, 5304) #, 37203
         @test get_exit_node(g) isa DataTaskNode
 
         props = get_properties(g)
-        @test NODE_NUM_EXPECTED == props.noNodes
-        @test EDGE_NUM_EXPECTED == props.noEdges
+        @test NODE_NUM_EXPECTED == props.number_of_nodes
+        @test EDGE_NUM_EXPECTED == props.number_of_edges
     end
 
     f = get_compute_function(g, mm, cpu_st(), @__MODULE__)


### PR DESCRIPTION
This is necessary for the additional rework of closures, which now allow closures in more than 1 depth. This means that closures can now be applied recursively and scale to much larger function sizes. The passed `closures_size` is now taken as a guideline to calculate a recursive depth that is used, and from that the actual closure size is derived. For very large functions, it may, therefore, deviate from the passed value considerably.

FunctionCalls are now also ready for VectorizationNode operations in the future.

Closes #40 