### PR TITLE
Add concrete_input_type kwarg

### DIFF
--- a/src/code_gen/function.jl
+++ b/src/code_gen/function.jl
@@ -21,13 +21,26 @@ in your top level.
         compiler cannot optimize. For sufficiently large functions, a larger value means longer compile times but potentially faster execution time.
         **Note** that the actually used closure size might be different than the one passed here, since the function automatically chooses a size that
         is close to a n-th root of the total number of loc, based off the given size.
+`concrete_input_type` (default=`input_type(instance)`): A type that will be used as the expected input type of the generated function. If
+    omitted, the `input_type` of the problem instance is used. Note that the `input_type` of the instance will still be used as the annotated
+    type in the generated function header.
 """
 function get_compute_function(
-    graph::DAG, instance, machine::Machine, context_module::Module; closures_size=0
+    graph::DAG,
+    instance,
+    machine::Machine,
+    context_module::Module;
+    closures_size::Int=0,
+    concrete_input_type::Type=Nothing,
 )
     tape = gen_tape(graph, instance, machine, context_module)
 
-    code = gen_function_body(tape, context_module; closures_size=closures_size)
+    code = gen_function_body(
+        tape,
+        context_module;
+        closures_size=closures_size,
+        concrete_input_type=concrete_input_type,
+    )
     assign_inputs = Expr(:block, expr_from_fc.(tape.input_assign_code)...)
 
     function_id = to_var_name(UUIDs.uuid1(rng[1]))

--- a/src/code_gen/tape_machine.jl
+++ b/src/code_gen/tape_machine.jl
@@ -92,10 +92,17 @@ Generate the function body from the given [`Tape`](@ref).
 `closures_size`: The size of closures to generate (in lines of code). Closures introduce function barriers
     in the function body, preventing some optimizations by the compiler and therefore greatly reducing
     compile time. A value of 0 will disable the use of closures entirely.
+`concrete_input_type`: A type that will be used as the expected input type of the generated function. If
+    omitted, the `input_type` of the problem instance is used.
 """
-function gen_function_body(tape::Tape, context_module::Module; closures_size::Int)
+function gen_function_body(
+    tape::Tape,
+    context_module::Module;
+    closures_size::Int,
+    concrete_input_type::Type=Nothing,
+)
     # only need to annotate types later when using closures
-    types = infer_types!(tape, context_module)
+    types = infer_types!(tape, context_module; concrete_input_type=concrete_input_type)
 
     if closures_size > 1
         s = log(closures_size, length(tape.schedule))

--- a/src/code_gen/utils.jl
+++ b/src/code_gen/utils.jl
@@ -9,11 +9,16 @@ end
 Infer the result type of each function call in the given tape. Returns a dictionary with the result type for each symbol and sets each function call's return_types.
 This function assumes that each [`FunctionCall`](@ref) has only one statically inferrable return type and will throw an exception otherwise.
 """
-function infer_types!(tape::Tape, context_module::Module)
+function infer_types!(tape::Tape, context_module::Module; concrete_input_type::Type=Nothing)
     known_result_types = Dict{Symbol,Type}()
 
-    # the only initially known type
-    known_result_types[:input] = input_type(tape.instance)
+    if concrete_input_type == Nothing   # the type, not the value "nothing"
+        # the only initially known type
+        known_result_types[:input] = input_type(tape.instance)
+    else
+        @debug "using given concrete input type $(concrete_input_type)"
+        known_result_types[:input] = concrete_input_type
+    end
 
     for fc in tape.input_assign_code
         res_types = result_types(fc, known_result_types, context_module)
@@ -35,6 +40,22 @@ function infer_types!(tape::Tape, context_module::Module)
         )
             known_result_types[s] = t
         end
+    end
+
+    if any(
+        x -> x == Any,
+        getindex.(
+            Ref(known_result_types), Iterators.flatten(last(tape.schedule).return_symbols)
+        ),
+    )
+        @warn "the inferred return type of the function is 'Any', which will likely lead to problems\ntry to \n\t 1: provide a more specific function argument type in your 'input_type' (got: $(input_type(tape.instance)))\n\t 2: increase your compute functions' type stability" *
+            (
+            if concrete_input_type == Nothing
+                "\n\t 3: try passing a 'concrete_input_type' as a keyword argument to the function generation"
+            else
+                ""
+            end
+        )
     end
 
     return known_result_types

--- a/src/task/compute.jl
+++ b/src/task/compute.jl
@@ -94,15 +94,18 @@ function result_types(
     fc::FunctionCall{VAL_T,F_T}, known_res_types::Dict{Symbol,Type}, context_module::Module
 ) where {VAL_T,F_T<:Function}
     arg_types = (_value_argument_types(fc)..., _argument_types(known_res_types, fc)...)
+    @debug "checking $(fc.func) with arg types $(arg_types)"
     types = Base.return_types(fc.func, arg_types)
 
     _validate_result_types(fc, types, arg_types)
 
     N_RET = length(fc.return_types)
     if (N_RET == 1)
+        @debug "found return type $(types[1])"
         return [types[1]]
     end
 
+    @debug "found return types $(types[1].parameters...)"
     return [types[1].parameters...]
 end
 

--- a/test/strassen_test.jl
+++ b/test/strassen_test.jl
@@ -59,4 +59,13 @@ EDGE_NUMBERS = (3, 96, 747, 5304) #, 37203
         @test Base.return_types(f_closures, (typeof(input),))[1] == typeof(input[1])
         @test isapprox(f_closures(input), input[1] * input[2])
     end
+
+    @testset "Function generation with concrete input type" begin
+        f_closures = get_compute_function(
+            g, mm, cpu_st(), @__MODULE__; concrete_input_type=typeof(input)
+        )
+
+        @test Base.return_types(f_closures, (typeof(input),))[1] == typeof(input[1])
+        @test isapprox(f_closures(input), input[1] * input[2])
+    end
 end


### PR DESCRIPTION
This adds a new keyword argument `concrete_input_type` to the function generation. It's used for the argument inferring during generation as the input type instead of the provided `input_type(instance)`.